### PR TITLE
Create runtime check macros

### DIFF
--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -1,0 +1,12 @@
+#if (!defined INQUERY_CORE_HEADER_INCLUDED)
+#define INQUERY_CORE_HEADER_INCLUDED
+
+
+#if (defined __GNUC__ || defined __clang__)
+#   define inq_likely(p) (__builtin_expect (!!(p), 1))
+#else
+#   define inq_likely(p) (p)
+#endif
+
+#endif /* INQUERY_CORE_HEADER_INCLUDED */
+

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -6,6 +6,7 @@
 #   define inq_likely(p) (__builtin_expect (!!(p), 1))
 #else
 #   define inq_likely(p) (p)
+#   warning "inq_likely() has no effect on non GCC-compatible C compilers"
 #endif
 
 
@@ -13,6 +14,7 @@
 #   define inq_unlikely(p) (__builtin_expect (!!(p), 0))
 #else
 #   define inq_unlikely(p) (p)
+#   warning "inq_likely() has no effect on non GCC-compatible C compilers"
 #endif
 
 

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -18,5 +18,19 @@
 #endif
 
 
+#if !(defined NDEBUG)
+#   define inq_assert(p)                                               \
+    do {                                                               \
+        if (inq_unlikely (!(p))) {                                     \
+            printf("inq_assert() condition failed: %s [%s, %s, %d]\n", \
+                    #p, __func__, __FILE__, __LINE__);                 \
+            abort();                                                   \
+        }                                                              \
+    } while (0)
+#else
+#   define inq_assert(p)
+#endif
+
+
 #endif /* INQUERY_CORE_HEADER_INCLUDED */
 

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -8,5 +8,13 @@
 #   define inq_likely(p) (p)
 #endif
 
+
+#if (defined __GNUC__ || defined __clang__)
+#   define inq_unlikely(p) (__builtin_expect (!!(p), 0))
+#else
+#   define inq_unlikely(p) (p)
+#endif
+
+
 #endif /* INQUERY_CORE_HEADER_INCLUDED */
 

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -2,6 +2,11 @@
 #define INQUERY_CORE_HEADER_INCLUDED
 
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+
 #if (defined __GNUC__ || defined __clang__)
 #   define inq_likely(p) (__builtin_expect (!!(p), 1))
 #else
@@ -19,8 +24,7 @@
 
 
 #if !(defined NDEBUG)
-#   define inq_assert(p)                                               \
-    do {                                                               \
+#   define inq_assert(p) do {                                          \
         if (inq_unlikely (!(p))) {                                     \
             printf("inq_assert() condition failed: %s [%s, %s, %d]\n", \
                     #p, __func__, __FILE__, __LINE__);                 \
@@ -28,8 +32,17 @@
         }                                                              \
     } while (0)
 #else
-#   define inq_assert(p)
+#   define inq_assert(p) ((void 0)
 #endif
+
+
+#define inq_require(p) do {                                           \
+    if (inq_unlikely (!(p))) {                                        \
+        printf("inq_require() condition failed @ %s() [%s:%d]: %s\n", \
+                __func__, __FILE__, __LINE__, #p);                    \
+        exit(EXIT_FAILURE);                                           \
+    }                                                                 \
+} while (0)
 
 
 #endif /* INQUERY_CORE_HEADER_INCLUDED */

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -1,3 +1,27 @@
+/******************************************************************************
+ *                     ___                                   
+ *                    |_ _|_ __   __ _ _   _  ___ _ __ _   _ 
+ *                     | || '_ \ / _` | | | |/ _ \ '__| | | |
+ *                     | || | | | (_| | |_| |  __/ |  | |_| |
+ *                    |___|_| |_|\__, |\__,_|\___|_|   \__, |
+ *                                  |_|                |___/ 
+ *
+ * Inquery - India Query RESTful microservice
+ * Copyright (c) 2020 Abhishek Chakravarti <abhishek@taranjali.org>. 
+ * See the accompanying inquery/AUTHORS file for the full list of contributors.
+ *
+ * This is the inquery/lib/core.h header file; it declares the core interface
+ * on which the Inquery microservice is built.
+ *
+ * This code is released under the GPLv3 License. See the accompanying 
+ * inquery/LICENSE file or <http://opensource.org/licenses/GPL-3.0> for complete
+ * licensing details.
+ *
+ * BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT YOU
+ * HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
 #if (!defined INQUERY_CORE_HEADER_INCLUDED)
 #define INQUERY_CORE_HEADER_INCLUDED
 

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -31,6 +31,9 @@
 #include <assert.h>
 
 
+/*
+ * inq_likely() - hint that a predicate is likely to be true
+ */
 #if (defined __GNUC__ || defined __clang__)
 #   define inq_likely(p) (__builtin_expect (!!(p), 1))
 #else
@@ -39,6 +42,9 @@
 #endif
 
 
+/*
+ * inq_unlikely() - hint that a predicate is unlikely to be true
+ */
 #if (defined __GNUC__ || defined __clang__)
 #   define inq_unlikely(p) (__builtin_expect (!!(p), 0))
 #else
@@ -47,6 +53,9 @@
 #endif
 
 
+/*
+ * inq_assert() - assert that a predicate is true
+ */
 #if !(defined NDEBUG)
 #   define inq_assert(p) do {                                          \
         if (inq_unlikely (!(p))) {                                     \
@@ -60,6 +69,9 @@
 #endif
 
 
+/*
+ * inq_require() - ensure that a predicate is true
+ */
 #define inq_require(p) do {                                           \
     if (inq_unlikely (!(p))) {                                        \
         printf("inq_require() condition failed @ %s() [%s:%d]: %s\n", \


### PR DESCRIPTION
The runtime check macros `inq_assert()` and `inq_require()` have been introduced. The `inq_assert()` macro asserts at runtime that a given precondition is true, and aborts if the check fails. The `inq_require()` macro checks whether a post-condition is true, and exits with the `EXIT_FAILURE` code if the check fails.

Ideally, `inq_require()` should have access to an exception handler callback function that it can call in case of failure of the check; this is, however, deferred to a later issue.

Additionally, the branch prediction hint macros `inq_likely()` and `inq_unlikely()` have also been defined as they are used by the runtime check macros. These branch prediction macros are modelled after the Linux `likely()` and `unlikely()` macros.