### PR TITLE
Create heap interface

### DIFF
--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -31,6 +31,11 @@
 #include <assert.h>
 
 
+/*******************************************************************************
+ * BRANCH PREDICTION
+ */
+
+
 /*
  * inq_likely() - hint that a predicate is likely to be true
  */
@@ -53,6 +58,11 @@
 #endif
 
 
+/*******************************************************************************
+ * RUNTIME CHECKS
+ */
+
+
 /*
  * inq_assert() - assert that a predicate is true
  */
@@ -65,7 +75,7 @@
         }                                                              \
     } while (0)
 #else
-#   define inq_assert(p) ((void 0)
+#   define inq_assert(p)
 #endif
 
 
@@ -79,6 +89,22 @@
         exit(EXIT_FAILURE);                                           \
     }                                                                 \
 } while (0)
+
+
+/*******************************************************************************
+ * HEAP MEMORY MANAGEMENT
+ */
+
+
+#define inq_heap_init()
+
+#define inq_heap_exit()
+
+extern void *inq_heap_new(size_t sz);
+
+extern void *inq_heap_resize(void *bfr, size_t sz);
+
+extern void inq_heap_free(void **bfr);
 
 
 #endif /* INQUERY_CORE_HEADER_INCLUDED */

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -102,7 +102,7 @@
 
 extern void *inq_heap_new(size_t sz);
 
-extern void *inq_heap_resize(void *bfr, size_t sz);
+extern void inq_heap_resize(void **bfr, size_t sz);
 
 extern void inq_heap_free(void **bfr);
 

--- a/lib/core/heap.c
+++ b/lib/core/heap.c
@@ -1,0 +1,32 @@
+#include <string.h>
+#include "core.h"
+
+
+extern void *inq_heap_new(size_t sz)
+{
+    void *bfr;
+
+    inq_assert (sz);
+    inq_require (bfr  = malloc(sz));
+    
+    memset(bfr, 0, sz);
+    return bfr;
+}
+
+
+extern void inq_heap_resize(void **bfr, size_t sz)
+{
+    inq_assert (bfr && *bfr && sz);
+    inq_require (*bfr = realloc(*bfr, sz));
+
+}
+
+
+extern void inq_heap_free(void **bfr)
+{
+    if (inq_likely (bfr && *bfr)) {
+        free(*bfr);
+        *bfr = NULL;
+    }
+}
+

--- a/test/heap.c
+++ b/test/heap.c
@@ -1,0 +1,74 @@
+#include "../lib/core/core.h"
+#include "suite.h"
+
+
+/*
+ * test_new() - inq_heap_new() test case
+ */
+static void test_new(void)
+{
+    printf("inq_heap_new() dynamically allocates memory on the heap...");
+
+    int *bfr = inq_heap_new(sizeof *bfr);
+    *bfr = 555;
+
+    inq_require (*bfr == 555);
+    inq_heap_free((void **) &bfr);
+
+    printf("OK\n");
+}
+
+
+/*
+ * test_resize() - inq_heap_resize() test case
+ */
+static void test_resize(void)
+{
+    printf("inq_heap_resize() resizes an existing heap memory buffer...");
+
+    int *bfr = inq_heap_new(sizeof *bfr);
+    *bfr = 555;
+    inq_require (*bfr == 555);
+
+    inq_heap_resize((void **) &bfr, sizeof *bfr * 2);
+    inq_require (*bfr == 555);
+
+    bfr[1] = 666;
+    inq_require (bfr[1] == 666);
+    
+    printf("OK\n");
+}
+
+
+/*
+ * test_free() - inq_heap_free() test case
+ */
+static void test_free(void)
+{
+    printf("inq_heap_free() releases an existing heap memory buffer...");
+
+    int *bfr = inq_heap_new(sizeof *bfr);
+    inq_require (bfr);
+
+    inq_heap_free((void **) &bfr);
+    inq_require (!bfr);
+    
+    printf("OK\n");
+}
+
+
+/*
+ * inq_test_suite_heap() - heap memory interface test suite
+ */
+extern void inq_test_suite_heap(void)
+{
+    printf("===============================================================\n");
+    printf("Starting heap interface test suite...\n\n");
+
+    test_new();
+    test_resize();
+    test_free();
+
+    printf("\n");
+}
+

--- a/test/runner.c
+++ b/test/runner.c
@@ -1,7 +1,12 @@
+#include "suite.h"
+
+
 int main(int argc, char **argv)
 {
     (void) argc;
     (void) argv;
+
+    inq_test_suite_heap();
 
     return 0;
 }

--- a/test/suite.h
+++ b/test/suite.h
@@ -1,0 +1,10 @@
+#if (!defined INQUERY_TEST_SUITE_HEADER)
+#define INQUERY_TEST_SUITE_HEADER
+
+/*
+ * inq_test_suite_heap() - heap memory interface test suite
+ */
+extern void inq_test_suite_heap(void);
+
+#endif /* INQUERY_TEST_SUITE_HEADER */
+


### PR DESCRIPTION
The heap memory management interface has been created with the following macros and functions:
* `inq_heap_init()`
* `inq_heap_exit()`
* `inq_heap_new()`
* `inq_heap_resize()`
* `inq_heap_free()`

The `inq_heap_init()` and `inq_heap_exit()` macros are currently empty, but have been kept in case we decide at a later stage to use a memory manager that requires initialisation and cleanup. 

`inq_heap_new()` allocates a new block of heap memory, ensuring that the returned pointer is valid and initialised to `0`. `inq_heap_resize()` resizes an existing heap memory buffer, and `inq_heap_free()` releases a previously allocated block of heap memory, ensuring that it is set to `NULL` in order to prevent dangling pointers.

The first set of unit tests for `inq_heap_new()`, `inq_heap_resize()` and `inq_heap_free()` have also been added.

This pull request closes #4.