### PR TITLE
Create object model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,6 @@ dkms.conf
 
 # Build artefacts
 bld/
+.clangd/
 compile_commands.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,5 @@ dkms.conf
 
 # Build artefacts
 bld/
+compile_commands.json
 

--- a/Makefile
+++ b/Makefile
@@ -160,9 +160,12 @@ test: $(BIN_TEST)
 #
 # The target to run the Valgrind checks.
 #
-check: $(BIN_EXE)
+check: $(BIN_TEST) $(BIN_EXE)
 	valgrind --tool=memcheck --leak-check=full --show-leak-kinds=all \
-		--track-origins=yes --log-file=$(DIR_BLD)/valgrind.log   \
+		--track-origins=yes --log-file=$(BIN_TEST).vglog         \
+		$(BIN_TEST)
+	valgrind --tool=memcheck --leak-check=full --show-leak-kinds=all \
+		--track-origins=yes --log-file=$(BIN_EXE).vglog          \
 		$(BIN_EXE)
 
 #

--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,12 @@ check: $(BIN_EXE)
 		--track-origins=yes --log-file=$(DIR_BLD)/valgrind.log   \
 		$(BIN_EXE)
 
+#
+# The target to build the compile database for LLVM using BEAR
+#
+compiledb: clean
+	bear make all
+
 
 #
 # The list of phony targets.

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -149,10 +149,11 @@ struct inquery_object_vtable {
  * inquery_object_smart - declare smart pointer to object
  */
 #if (defined __GNUC__ || defined __clang__)
-#   define inquery_object_smart __attribute__((cleanup(inquery_object_free)))
+#   define inquery_object_smart \
+            __attribute__((cleanup(inquery_object_free))) inquery_object
 #else
-#   define inquery_object_smart
-#   warning "inquery_object_smart has no effect on non GCC-compatible compilers"
+#   define inquery_object_smart inquery_object
+#   warning "inquery_object_smart leaks memory on non GCC-compatible compilers"
 #endif
 
 

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -141,7 +141,7 @@ typedef struct inquery_object inquery_object;
  */
 struct inquery_object_vtable {
     void *(*payload_copy)(const void *payload);
-    void (*payload_free)(void **payload);
+    void (*payload_free)(void *payload);
 };
 
 
@@ -159,8 +159,14 @@ struct inquery_object_vtable {
 /*
  * inquery_object_new() - create new object
  */
-extern inquery_object *inquery_object_new(size_t id, void *payload,
+extern inquery_object *inquery_object_new(void *payload,
         const struct inquery_object_vtable *vt);
+
+
+/*
+ * inquery_object_new_noload() - create new object without payload
+ */
+extern inquery_object *inquery_object_new_noload(void);
 
 
 /*

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -95,15 +95,33 @@
  * HEAP MEMORY MANAGEMENT
  */
 
-
+/*
+ * inq_heap_init() - initialise heap memory manager
+ */
 #define inq_heap_init()
 
+
+/*
+ * inq_heap_exit() - shut down heap memory manager
+ */
 #define inq_heap_exit()
 
+
+/*
+ * inq_heap_new() - allocate new block of heap memory
+ */
 extern void *inq_heap_new(size_t sz);
 
+
+/*
+ * inq_heap_resize() - resize existing block of heap memory
+ */
 extern void inq_heap_resize(void **bfr, size_t sz);
 
+
+/*
+ * inq_heap_free() - free existing block of heap memory
+ */
 extern void inq_heap_free(void **bfr);
 
 

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -130,15 +130,24 @@ extern void inquery_heap_free(void **bfr);
  */
 
 
+/*
+ * inquery_object - reference counted object
+ */
 typedef struct inquery_object inquery_object;
 
 
+/*
+ * struct inquery_object_vtable - object payload v-table
+ */
 struct inquery_object_vtable {
     void *(*payload_copy)(const void *payload);
     void (*payload_free)(void **payload);
 };
 
 
+/*
+ * inquery_object_smart - declare smart pointer to object
+ */
 #if (defined __GNUC__ || defined __clang__)
 #   define inquery_object_smart __attribute__((cleanup(inquery_object_free)))
 #else
@@ -147,15 +156,34 @@ struct inquery_object_vtable {
 #endif
 
 
+/*
+ * inquery_object_new() - create new object
+ */
 extern inquery_object *inquery_object_new(size_t id, void *payload,
         const struct inquery_object_vtable *vt);
 
+
+/*
+ * inquery_object_copy() - copy existing object
+ */
 extern inquery_object *inquery_object_copy(const inquery_object *ctx);
 
+
+/*
+ * inquery_object_free() - free object from heap memory
+ */
 extern void inquery_object_free(inquery_object **ctx);
 
+
+/*
+ * inquery_object_payload() - get constant handle to object payload
+ */
 extern const void *inquery_object_payload(const inquery_object *ctx);
 
+
+/*
+ * inquery_object_payload_mutable() - get mutable handle to object payload
+ */
 extern void *inquery_object_payload_mutable(inquery_object **ctx);
 
 

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -43,7 +43,7 @@
 #   define inq_likely(p) (__builtin_expect (!!(p), 1))
 #else
 #   define inq_likely(p) (p)
-#   warning "inq_likely() has no effect on non GCC-compatible C compilers"
+#   warning "inq_likely() has no effect on non GCC-compatible compilers"
 #endif
 
 
@@ -54,7 +54,7 @@
 #   define inq_unlikely(p) (__builtin_expect (!!(p), 0))
 #else
 #   define inq_unlikely(p) (p)
-#   warning "inq_likely() has no effect on non GCC-compatible C compilers"
+#   warning "inq_likely() has no effect on non GCC-compatible compilers"
 #endif
 
 
@@ -123,6 +123,39 @@ extern void inq_heap_resize(void **bfr, size_t sz);
  * inq_heap_free() - free existing block of heap memory
  */
 extern void inq_heap_free(void **bfr);
+
+
+/*******************************************************************************
+ * OBJECT MODEL
+ */
+
+
+typedef struct inquery_object inquery_object;
+
+
+struct inquery_object_vtable {
+    void *(*payload_copy)(const void *payload);
+    void (*payload_free)(void **payload);
+};
+
+#if (defined __GNUC__ || defined __clang__)
+#   define inquery_object_smart __attribute__((cleanup(inquery_object_free)))
+#else
+#   define inquery_object_smart
+#   warning "inquery_object_smart has no effect on non GCC-compatible compilers"
+#endif
+
+
+extern inquery_object *inquery_object_new(size_t id, void *payload,
+        const struct inquery_object_vtable *vt);
+
+extern inquery_object *inquery_object_copy(const inquery_object *ctx);
+
+extern void inquery_object_free(inquery_object **ctx);
+
+extern const void *inquery_object_payload(const inquery_object *ctx);
+
+extern void *inquery_object_payload_mutable(inquery_object **ctx);
 
 
 #endif /* INQUERY_CORE_HEADER_INCLUDED */

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -37,24 +37,24 @@
 
 
 /*
- * inq_likely() - hint that a predicate is likely to be true
+ * inquery_likely() - hint that a predicate is likely to be true
  */
 #if (defined __GNUC__ || defined __clang__)
-#   define inq_likely(p) (__builtin_expect (!!(p), 1))
+#   define inquery_likely(p) (__builtin_expect (!!(p), 1))
 #else
-#   define inq_likely(p) (p)
-#   warning "inq_likely() has no effect on non GCC-compatible compilers"
+#   define inquery_likely(p) (p)
+#   warning "inquery_likely() has no effect on non GCC-compatible compilers"
 #endif
 
 
 /*
- * inq_unlikely() - hint that a predicate is unlikely to be true
+ * inquery_unlikely() - hint that a predicate is unlikely to be true
  */
 #if (defined __GNUC__ || defined __clang__)
-#   define inq_unlikely(p) (__builtin_expect (!!(p), 0))
+#   define inquery_unlikely(p) (__builtin_expect (!!(p), 0))
 #else
-#   define inq_unlikely(p) (p)
-#   warning "inq_likely() has no effect on non GCC-compatible compilers"
+#   define inquery_unlikely(p) (p)
+#   warning "inquery_likely() has no effect on non GCC-compatible compilers"
 #endif
 
 
@@ -64,30 +64,30 @@
 
 
 /*
- * inq_assert() - assert that a predicate is true
+ * inquery_assert() - assert that a predicate is true
  */
 #if !(defined NDEBUG)
-#   define inq_assert(p) do {                                          \
-        if (inq_unlikely (!(p))) {                                     \
-            printf("inq_assert() condition failed: %s [%s, %s, %d]\n", \
-                    #p, __func__, __FILE__, __LINE__);                 \
-            abort();                                                   \
-        }                                                              \
+#   define inquery_assert(p) do {                                          \
+        if (inquery_unlikely (!(p))) {                                     \
+            printf("inquery_assert() condition failed: %s [%s, %s, %d]\n", \
+                    #p, __func__, __FILE__, __LINE__);                     \
+            abort();                                                       \
+        }                                                                  \
     } while (0)
 #else
-#   define inq_assert(p)
+#   define inquery_assert(p)
 #endif
 
 
 /*
- * inq_require() - ensure that a predicate is true
+ * inquery_require() - ensure that a predicate is true
  */
-#define inq_require(p) do {                                           \
-    if (inq_unlikely (!(p))) {                                        \
-        printf("inq_require() condition failed @ %s() [%s:%d]: %s\n", \
-                __func__, __FILE__, __LINE__, #p);                    \
-        exit(EXIT_FAILURE);                                           \
-    }                                                                 \
+#define inquery_require(p) do {                                           \
+    if (inquery_unlikely (!(p))) {                                        \
+        printf("inquery_require() condition failed @ %s() [%s:%d]: %s\n", \
+                __func__, __FILE__, __LINE__, #p);                        \
+        exit(EXIT_FAILURE);                                               \
+    }                                                                     \
 } while (0)
 
 
@@ -96,33 +96,33 @@
  */
 
 /*
- * inq_heap_init() - initialise heap memory manager
+ * inquery_heap_init() - initialise heap memory manager
  */
-#define inq_heap_init()
+#define inquery_heap_init()
 
 
 /*
- * inq_heap_exit() - shut down heap memory manager
+ * inquery_heap_exit() - shut down heap memory manager
  */
-#define inq_heap_exit()
+#define inquery_heap_exit()
 
 
 /*
- * inq_heap_new() - allocate new block of heap memory
+ * inquery_heap_new() - allocate new block of heap memory
  */
-extern void *inq_heap_new(size_t sz);
+extern void *inquery_heap_new(size_t sz);
 
 
 /*
- * inq_heap_resize() - resize existing block of heap memory
+ * inquery_heap_resize() - resize existing block of heap memory
  */
-extern void inq_heap_resize(void **bfr, size_t sz);
+extern void inquery_heap_resize(void **bfr, size_t sz);
 
 
 /*
- * inq_heap_free() - free existing block of heap memory
+ * inquery_heap_free() - free existing block of heap memory
  */
-extern void inq_heap_free(void **bfr);
+extern void inquery_heap_free(void **bfr);
 
 
 /*******************************************************************************
@@ -137,6 +137,7 @@ struct inquery_object_vtable {
     void *(*payload_copy)(const void *payload);
     void (*payload_free)(void **payload);
 };
+
 
 #if (defined __GNUC__ || defined __clang__)
 #   define inquery_object_smart __attribute__((cleanup(inquery_object_free)))

--- a/lib/core/heap.c
+++ b/lib/core/heap.c
@@ -1,7 +1,34 @@
+/******************************************************************************
+ *                     ___                                   
+ *                    |_ _|_ __   __ _ _   _  ___ _ __ _   _ 
+ *                     | || '_ \ / _` | | | |/ _ \ '__| | | |
+ *                     | || | | | (_| | |_| |  __/ |  | |_| |
+ *                    |___|_| |_|\__, |\__,_|\___|_|   \__, |
+ *                                  |_|                |___/ 
+ *
+ * Inquery - India Query RESTful microservice
+ * Copyright (c) 2020 Abhishek Chakravarti <abhishek@taranjali.org>. 
+ * See the accompanying inquery/AUTHORS file for the full list of contributors.
+ *
+ * This is the inquery/lib/core/heap.c source file; it implements the heap 
+ * management interface declared in the inquery/lib/core/core.h header file.
+ *
+ * This code is released under the GPLv3 License. See the accompanying 
+ * inquery/LICENSE file or <http://opensource.org/licenses/GPL-3.0> for complete
+ * licensing details.
+ *
+ * BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT YOU
+ * HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
 #include <string.h>
 #include "core.h"
 
 
+/*
+ * inq_heap_new() - allocate new block of heap memory
+ */
 extern void *inq_heap_new(size_t sz)
 {
     void *bfr;
@@ -14,14 +41,19 @@ extern void *inq_heap_new(size_t sz)
 }
 
 
+/*
+ * inq_heap_resize() - resize existing block of heap memory
+ */
 extern void inq_heap_resize(void **bfr, size_t sz)
 {
     inq_assert (bfr && *bfr && sz);
     inq_require (*bfr = realloc(*bfr, sz));
-
 }
 
 
+/*
+ * inq_heap_free() - free existing block of heap memory
+ */
 extern void inq_heap_free(void **bfr)
 {
     if (inq_likely (bfr && *bfr)) {

--- a/lib/core/heap.c
+++ b/lib/core/heap.c
@@ -27,14 +27,14 @@
 
 
 /*
- * inq_heap_new() - allocate new block of heap memory
+ * inquery_heap_new() - allocate new block of heap memory
  */
-extern void *inq_heap_new(size_t sz)
+extern void *inquery_heap_new(size_t sz)
 {
     void *bfr;
 
-    inq_assert (sz);
-    inq_require (bfr  = malloc(sz));
+    inquery_assert (sz);
+    inquery_require (bfr = malloc(sz));
     
     memset(bfr, 0, sz);
     return bfr;
@@ -42,21 +42,21 @@ extern void *inq_heap_new(size_t sz)
 
 
 /*
- * inq_heap_resize() - resize existing block of heap memory
+ * inquery_heap_resize() - resize existing block of heap memory
  */
-extern void inq_heap_resize(void **bfr, size_t sz)
+extern void inquery_heap_resize(void **bfr, size_t sz)
 {
-    inq_assert (bfr && *bfr && sz);
-    inq_require (*bfr = realloc(*bfr, sz));
+    inquery_assert (bfr && *bfr && sz);
+    inquery_require (*bfr = realloc(*bfr, sz));
 }
 
 
 /*
- * inq_heap_free() - free existing block of heap memory
+ * inquery_heap_free() - free existing block of heap memory
  */
-extern void inq_heap_free(void **bfr)
+extern void inquery_heap_free(void **bfr)
 {
-    if (inq_likely (bfr && *bfr)) {
+    if (inquery_likely (bfr && *bfr)) {
         free(*bfr);
         *bfr = NULL;
     }

--- a/lib/core/object.c
+++ b/lib/core/object.c
@@ -1,0 +1,155 @@
+/******************************************************************************
+ *                     ___                                   
+ *                    |_ _|_ __   __ _ _   _  ___ _ __ _   _ 
+ *                     | || '_ \ / _` | | | |/ _ \ '__| | | |
+ *                     | || | | | (_| | |_| |  __/ |  | |_| |
+ *                    |___|_| |_|\__, |\__,_|\___|_|   \__, |
+ *                                  |_|                |___/ 
+ *
+ * Inquery - India Query RESTful microservice
+ * Copyright (c) 2020 Abhishek Chakravarti <abhishek@taranjali.org>. 
+ * See the accompanying inquery/AUTHORS file for the full list of contributors.
+ *
+ * This is the inquery/lib/core/object.c source file; it implements the object 
+ * model interface declared in the inquery/lib/core/core.h header file.
+ *
+ * This code is released under the GPLv3 License. See the accompanying 
+ * inquery/LICENSE file or <http://opensource.org/licenses/GPL-3.0> for complete
+ * licensing details.
+ *
+ * BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT YOU
+ * HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT THEM.
+ ******************************************************************************/
+
+
+#include "core.h"
+
+
+/*
+ * inquery_object - reference counted object
+ */
+struct inquery_object {
+    struct inquery_object_vtable vt;
+    size_t nref;
+    void *payload;
+};
+
+
+/*
+ * payload_copy_default() - default copy callback for payload v-table
+ */
+static inline void *payload_copy_default(const void *payload)
+{
+    return (void *) payload;;
+}
+
+
+/*
+ * payload_free_default() - default free callback for payload v-table
+ */
+static inline void payload_free_default(void *payload)
+{
+    (void) payload;
+}
+
+
+/*
+ * inquery_object_new() - create new object
+ */
+extern inquery_object *inquery_object_new(void *payload,
+        const struct inquery_object_vtable *vt)
+{
+    inquery_assert (payload);
+    inquery_assert (vt);
+
+    inquery_object *ctx = inquery_heap_new(sizeof *ctx);
+
+    ctx->nref = 1;
+    ctx->payload = payload;
+
+    ctx->vt.payload_copy = vt->payload_copy 
+            ? vt->payload_copy : payload_copy_default;
+    ctx->vt.payload_free = vt->payload_free 
+            ? vt->payload_free : payload_free_default;
+
+    return ctx;
+}
+
+
+/*
+ * inquery_object_new_noload() - create new object without payload
+ */
+extern inquery_object *inquery_object_new_noload(void)
+{
+    inquery_object *ctx = inquery_heap_new(sizeof *ctx);
+
+    ctx->nref = 1;
+    ctx->payload = NULL;
+
+    ctx->vt.payload_copy = payload_copy_default;
+    ctx->vt.payload_free = payload_free_default;
+
+    return ctx;
+}
+
+
+/*
+ * inquery_object_copy() - copy existing object
+ */
+extern inquery_object *inquery_object_copy(const inquery_object *ctx)
+{
+    inquery_assert (ctx);
+
+    inquery_object *cp = (inquery_object *) ctx;
+    cp->nref++;
+
+    return cp;
+}
+
+
+/*
+ * inquery_object_free() - free object from heap memory
+ */
+extern void inquery_object_free(inquery_object **ctx)
+{
+    inquery_object *hnd;
+
+    if (inquery_likely (ctx && (hnd = *ctx))) {
+        if (!--hnd->nref) {
+            hnd->vt.payload_free(hnd->payload);
+            inquery_heap_free(&hnd->payload);
+            inquery_heap_free((void **) ctx);
+        }
+    }
+}
+
+
+/*
+ * inquery_object_payload() - get constant handle to object payload
+ */
+extern const void *inquery_object_payload(const inquery_object *ctx)
+{
+    inquery_assert (ctx);
+
+    return ctx->payload;
+}
+
+
+/*
+ * inquery_object_payload_mutable() - get mutable handle to object payload
+ */
+extern void *inquery_object_payload_mutable(inquery_object **ctx)
+{
+    inquery_assert (ctx && *ctx);
+
+    inquery_object *hnd = *ctx;
+    if (hnd->nref > 1) {
+        inquery_object *cp = inquery_object_new(
+                hnd->vt.payload_copy(hnd->payload), &hnd->vt);
+        inquery_object_free(ctx);
+        *ctx = cp;
+    }
+
+    return (*ctx)->payload;
+}
+

--- a/test/heap.c
+++ b/test/heap.c
@@ -56,7 +56,7 @@ static void test_free(void)
     printf("OK\n");
 }
 
-  
+   
 /*
  * inquery_test_suite_heap() - heap memory interface test suite
  */

--- a/test/heap.c
+++ b/test/heap.c
@@ -3,64 +3,64 @@
 
 
 /*
- * test_new() - inq_heap_new() test case
+ * test_new() - inquery_heap_new() test case
  */
 static void test_new(void)
 {
-    printf("inq_heap_new() dynamically allocates memory on the heap...");
+    printf("inquery_heap_new() dynamically allocates memory on the heap...");
 
-    int *bfr = inq_heap_new(sizeof *bfr);
+    int *bfr = inquery_heap_new(sizeof *bfr);
     *bfr = 555;
 
-    inq_require (*bfr == 555);
-    inq_heap_free((void **) &bfr);
+    inquery_require (*bfr == 555);
+    inquery_heap_free((void **) &bfr);
 
     printf("OK\n");
 }
 
 
 /*
- * test_resize() - inq_heap_resize() test case
+ * test_resize() - inquery_heap_resize() test case
  */
 static void test_resize(void)
 {
-    printf("inq_heap_resize() resizes an existing heap memory buffer...");
+    printf("inquery_heap_resize() resizes an existing heap memory buffer...");
 
-    int *bfr = inq_heap_new(sizeof *bfr);
+    int *bfr = inquery_heap_new(sizeof *bfr);
     *bfr = 555;
-    inq_require (*bfr == 555);
+    inquery_require (*bfr == 555);
 
-    inq_heap_resize((void **) &bfr, sizeof *bfr * 2);
-    inq_require (*bfr == 555);
+    inquery_heap_resize((void **) &bfr, sizeof *bfr * 2);
+    inquery_require (*bfr == 555);
 
     bfr[1] = 666;
-    inq_require (bfr[1] == 666);
+    inquery_require (bfr[1] == 666);
     
     printf("OK\n");
 }
 
 
 /*
- * test_free() - inq_heap_free() test case
+ * test_free() - inquery_heap_free() test case
  */
 static void test_free(void)
 {
-    printf("inq_heap_free() releases an existing heap memory buffer...");
+    printf("inquery_heap_free() releases an existing heap memory buffer...");
 
-    int *bfr = inq_heap_new(sizeof *bfr);
-    inq_require (bfr);
+    int *bfr = inquery_heap_new(sizeof *bfr);
+    inquery_require (bfr);
 
-    inq_heap_free((void **) &bfr);
-    inq_require (!bfr);
+    inquery_heap_free((void **) &bfr);
+    inquery_require (!bfr);
     
     printf("OK\n");
 }
 
-
+  
 /*
- * inq_test_suite_heap() - heap memory interface test suite
+ * inquery_test_suite_heap() - heap memory interface test suite
  */
-extern void inq_test_suite_heap(void)
+extern void inquery_test_suite_heap(void)
 {
     printf("===============================================================\n");
     printf("Starting heap interface test suite...\n\n");

--- a/test/heap.c
+++ b/test/heap.c
@@ -35,6 +35,7 @@ static void test_resize(void)
 
     bfr[1] = 666;
     inquery_require (bfr[1] == 666);
+    inquery_heap_free((void **) &bfr);
     
     printf("OK\n");
 }

--- a/test/object.c
+++ b/test/object.c
@@ -1,0 +1,145 @@
+#include "../lib/core/core.h"
+#include "suite.h"
+
+
+/*
+ * struct payload - sample payload for testing
+ */
+struct payload {
+    int x;
+    int y;
+};
+
+
+/*
+ * test_new() - inquery_object() test case
+ */
+static void test_new(void)
+{
+    printf("inquery_object_new() creates an object with a payload...");
+
+    struct payload *p = inquery_heap_new(sizeof *p);
+    p->x = 555;
+    p->y = 666;
+
+    struct inquery_object_vtable vt = { 
+        .payload_copy = NULL, 
+        .payload_free = NULL
+    };
+
+    inquery_object_smart *obj = inquery_object_new(p, &vt);
+    inquery_require (obj);
+
+    printf("OK\n");
+}
+
+
+/*
+ * test_new_noload() - inquery_object_new_noload() test case
+ */
+static void test_new_noload(void)
+{
+    printf("inquery_object_new_noload() creates an object with no payload...");
+
+    inquery_object_smart *obj = inquery_object_new_noload();
+    
+    inquery_require (obj);
+    inquery_require (!inquery_object_payload(obj));
+
+    printf("OK\n");
+}
+
+
+/*
+ * test_free() - inquery_object_free() test case
+ */
+static void test_free(void)
+{
+    printf("inquery_object_free() releases an object...");
+    
+    inquery_object *obj = inquery_object_new_noload();
+    inquery_require (obj);
+
+    inquery_object_free(&obj);
+    inquery_require (!obj);
+
+    printf("OK\n");
+}
+
+
+/*
+ * test_payload() - inquery_object_payload() test case
+ */
+static void test_payload(void)
+{
+    printf("inquery_object_payload() gets a handle to the payload...");
+
+    struct payload *tmp = inquery_heap_new(sizeof *tmp);
+    tmp->x = 555;
+    tmp->y = 666;
+
+    struct inquery_object_vtable vt = { 
+        .payload_copy = NULL, 
+        .payload_free = NULL
+    };
+
+    inquery_object_smart *obj = inquery_object_new(tmp, &vt);
+    inquery_require (obj);
+
+    const struct payload *p = inquery_object_payload(obj);
+    inquery_require (p->x == 555);
+    inquery_require (p->y == 666);
+
+    printf("OK\n");
+}
+
+
+/*
+ * test_payload_mutable() - inquery_object_payload_mutable() test case
+ */
+static void test_payload_mutable(void)
+{
+    printf("inquery_object_payload_mutable() gets a mutable handle to the"
+            " payload...");
+
+    struct payload *tmp = inquery_heap_new(sizeof *tmp);
+    tmp->x = 555;
+    tmp->y = 666;
+
+    struct inquery_object_vtable vt = { 
+        .payload_copy = NULL, 
+        .payload_free = NULL
+    };
+
+    inquery_object_smart *obj = inquery_object_new(tmp, &vt);
+    inquery_require (obj);
+
+    struct payload *p = inquery_object_payload_mutable(&obj);
+    p->x = 666;
+    p->y = 555;
+    
+    inquery_require (p->x == 666);
+    inquery_require (p->y == 555);
+
+    printf("OK\n");
+}
+
+
+   
+/*
+ * inquery_test_suite_object() - object model interface test suite
+ */
+extern void inquery_test_suite_object(void)
+{
+    printf("===============================================================\n");
+    printf("Starting object model interface test suite...\n\n");
+
+    test_new();
+    test_new_noload();
+    test_free();
+    test_payload();
+    test_payload_mutable();
+
+    printf("\n");
+}
+

--- a/test/runner.c
+++ b/test/runner.c
@@ -7,6 +7,7 @@ int main(int argc, char **argv)
     (void) argv;
 
     inquery_test_suite_heap();
+    inquery_test_suite_object();
 
     return 0;
 }

--- a/test/runner.c
+++ b/test/runner.c
@@ -6,7 +6,7 @@ int main(int argc, char **argv)
     (void) argc;
     (void) argv;
 
-    inq_test_suite_heap();
+    inquery_test_suite_heap();
 
     return 0;
 }

--- a/test/suite.h
+++ b/test/suite.h
@@ -6,5 +6,12 @@
  */
 extern void inquery_test_suite_heap(void);
 
+
+/*
+ * inquery_test_suite_object() - object model interface test suite
+ */
+extern void inquery_test_suite_object(void);
+
+
 #endif /* INQUERY_TEST_SUITE_HEADER */
 

--- a/test/suite.h
+++ b/test/suite.h
@@ -2,9 +2,9 @@
 #define INQUERY_TEST_SUITE_HEADER
 
 /*
- * inq_test_suite_heap() - heap memory interface test suite
+ * inquery_test_suite_heap() - heap memory interface test suite
  */
-extern void inq_test_suite_heap(void);
+extern void inquery_test_suite_heap(void);
 
 #endif /* INQUERY_TEST_SUITE_HEADER */
 


### PR DESCRIPTION
The reference counted object model has been created with the following interface:
  * `inquery_object_new()`
  * `inquery_object_new_noload()`
  * `inquery_object_copy()`
  * `inquery_object_free()`
  * `inquery_object_payload()`
  * `inquery_object_payload_mutable()`

Supporting this interface are the following types:
  * `inquery_object`
  * `inquery_object_smart`
  * `struct inquery_object_vtable`

Brief descriptions have been given as comments, and unit tests for the object model interface have also been incorporated.

Other unrelated changes that have also been made include:
  * Adding a `compiledb` build target for Clang along with the related Git ignore rules
  * Renaming the namespace of the existing interface to `inquery_` from `inq_`
  * Checking the test runner with Valgrind in addition to the executable binary
  * Fixing a small memory leak bug in the heap manager test suite

This pull request closes #7.