### PR TITLE
Create string interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ $(DIR_BLD)/%.o: $(DIR_LIB)/%.c | $(DIR_BLD)
 # The rule to create the build directory.
 #
 $(DIR_BLD):
-	mkdir -p $@ $@/core
+	mkdir -p $@ $@/core $@/sds
 
 
 #

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -132,6 +132,14 @@ extern void inquery_heap_free(void **bfr);
 
 typedef char inquery_string;
 
+#if (defined __GNUC__ || defined __clang__)
+#   define inquery_string_smart \
+            __attribute__((cleanup(inquery_string_free))) inquery_string
+#else
+#   define inquery_string_smart inquery_string
+#   warning "inquery_string_smart leaks memory on non GCC-compatible compilers"
+#endif
+
 extern inquery_string *inquery_string_new(const char *cstr);
 
 extern inquery_string *inquery_string_new_empty(void);
@@ -171,8 +179,7 @@ inline bool inquery_string_gt(const inquery_string *lhs,
     return inquery_string_cmp(lhs, rhs) > 0;
 }
 
-extern inquery_string *inquery_string_add(const inquery_string *ctx, 
-        const inquery_string *add);
+extern void inquery_string_add(inquery_string **ctx, const inquery_string *add);
 
 extern size_t inquery_string_find(const inquery_string *haystack, 
         const inquery_string *needle);

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -26,6 +26,7 @@
 #define INQUERY_CORE_HEADER_INCLUDED
 
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -137,12 +138,38 @@ extern inquery_string *inquery_string_new_empty(void);
 
 extern inquery_string *inquery_string_copy(const inquery_string *ctx);
 
+extern void inquery_string_free(inquery_string **ctx);
+
 extern size_t inquery_string_len(const inquery_string *ctx);
 
 extern size_t inquery_string_sz(const inquery_string *ctx);
 
 extern int inquery_string_cmp(const inquery_string *lhs, 
         const inquery_string *rhs);
+
+inline bool inquery_string_lt(const inquery_string *lhs,
+        const inquery_string *rhs)
+{
+    inquery_assert (lhs && rhs);
+
+    return inquery_string_cmp(lhs, rhs) < 0;
+}
+
+inline bool inquery_string_eq(const inquery_string *lhs,
+        const inquery_string *rhs)
+{
+    inquery_assert (lhs && rhs);
+
+    return !inquery_string_cmp(lhs, rhs);
+}
+
+inline bool inquery_string_gt(const inquery_string *lhs,
+        const inquery_string *rhs)
+{
+    inquery_assert (lhs && rhs);
+
+    return inquery_string_cmp(lhs, rhs) > 0;
+}
 
 extern inquery_string *inquery_string_add(const inquery_string *ctx, 
         const inquery_string *add);

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -126,6 +126,39 @@ extern void inquery_heap_free(void **bfr);
 
 
 /*******************************************************************************
+ * STRING
+ */
+
+typedef char inquery_string;
+
+extern inquery_string *inquery_string_new(const char *cstr);
+
+extern inquery_string *inquery_string_new_empty(void);
+
+extern inquery_string *inquery_string_copy(const inquery_string *ctx);
+
+extern size_t inquery_string_len(const inquery_string *ctx);
+
+extern size_t inquery_string_sz(const inquery_string *ctx);
+
+extern int inquery_string_cmp(const inquery_string *lhs, 
+        const inquery_string *rhs);
+
+extern inquery_string *inquery_string_add(const inquery_string *ctx, 
+        const inquery_string *add);
+
+extern size_t inquery_string_find(const inquery_string *haystack, 
+        const inquery_string *needle);
+
+extern inquery_string *inquery_string_replace(const inquery_string *haystack, 
+        const inquery_string *needle, const inquery_string *replace);
+
+extern inquery_string *inquery_string_replace_first(
+        const inquery_string *haystack, const inquery_string *needle,
+        const inquery_string *replace);
+
+
+/*******************************************************************************
  * OBJECT MODEL
  */
 

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -181,15 +181,14 @@ inline bool inquery_string_gt(const inquery_string *lhs,
 
 extern void inquery_string_add(inquery_string **ctx, const inquery_string *add);
 
-extern size_t inquery_string_find(const inquery_string *haystack, 
-        const inquery_string *needle);
+extern size_t inquery_string_find(const inquery_string *ctx, 
+        const inquery_string *what);
 
-extern inquery_string *inquery_string_replace(const inquery_string *haystack, 
-        const inquery_string *needle, const inquery_string *replace);
+extern void inquery_string_replace(inquery_string **ctx, 
+        const inquery_string *what, const inquery_string *with);
 
-extern inquery_string *inquery_string_replace_first(
-        const inquery_string *haystack, const inquery_string *needle,
-        const inquery_string *replace);
+extern void inquery_string_replace_first(inquery_string **ctx, 
+        const inquery_string *what, const inquery_string *with);
 
 
 /*******************************************************************************

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -242,6 +242,13 @@ extern size_t inquery_string_find(const inquery_string *ctx,
 
 
 /*
+ * inquery_string_count() - count all occurrences of substring
+ */
+extern size_t inquery_string_count(const inquery_string *ctx,
+        const inquery_string *what);
+
+
+/*
  * inquery_string_replace() - replace all occurrences of substring
  */
 extern void inquery_string_replace(inquery_string **ctx, 

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -130,8 +130,16 @@ extern void inquery_heap_free(void **bfr);
  * STRING
  */
 
+
+/*
+ * inquery_string - UTF-8 string
+ */
 typedef char inquery_string;
 
+
+/*
+ * inquery_string_smart - smart string pointer
+ */
 #if (defined __GNUC__ || defined __clang__)
 #   define inquery_string_smart \
             __attribute__((cleanup(inquery_string_free))) inquery_string
@@ -140,21 +148,53 @@ typedef char inquery_string;
 #   warning "inquery_string_smart leaks memory on non GCC-compatible compilers"
 #endif
 
+
+/*
+ * inquery_string_new() - create new string
+ */
 extern inquery_string *inquery_string_new(const char *cstr);
 
+
+/*
+ * inquery_string_new_empty() - create new empty string
+ */
 extern inquery_string *inquery_string_new_empty(void);
 
+
+/*
+ * inquery_string_copy() - copy existing string
+ */
 extern inquery_string *inquery_string_copy(const inquery_string *ctx);
 
+
+/*
+ * inquery_string_free() - release string
+ */
 extern void inquery_string_free(inquery_string **ctx);
 
+
+/*
+ * inquery_string_len() - get length of string
+ */
 extern size_t inquery_string_len(const inquery_string *ctx);
 
+
+/*
+ * inquery_string_sz() - get size of string
+ */
 extern size_t inquery_string_sz(const inquery_string *ctx);
 
+
+/*
+ * inquery_string_cmp() - compare two strings
+ */
 extern int inquery_string_cmp(const inquery_string *lhs, 
         const inquery_string *rhs);
 
+
+/*
+ * inquery_string_lt() - check if string is less than another
+ */
 inline bool inquery_string_lt(const inquery_string *lhs,
         const inquery_string *rhs)
 {
@@ -163,6 +203,10 @@ inline bool inquery_string_lt(const inquery_string *lhs,
     return inquery_string_cmp(lhs, rhs) < 0;
 }
 
+
+/*
+ * inquery_string_eq() - check if string is equal to another
+ */
 inline bool inquery_string_eq(const inquery_string *lhs,
         const inquery_string *rhs)
 {
@@ -171,6 +215,10 @@ inline bool inquery_string_eq(const inquery_string *lhs,
     return !inquery_string_cmp(lhs, rhs);
 }
 
+
+/*
+ * inquery_string_gt() - check if string is greater than another
+ */
 inline bool inquery_string_gt(const inquery_string *lhs,
         const inquery_string *rhs)
 {
@@ -179,14 +227,30 @@ inline bool inquery_string_gt(const inquery_string *lhs,
     return inquery_string_cmp(lhs, rhs) > 0;
 }
 
+
+/*
+ * inquery_string_add() - concatenate two strings
+ */
 extern void inquery_string_add(inquery_string **ctx, const inquery_string *add);
 
+
+/*
+ * inquery_string_find() - find first occurrence of substring
+ */
 extern size_t inquery_string_find(const inquery_string *ctx, 
         const inquery_string *what);
 
+
+/*
+ * inquery_string_replace() - replace all occurrences of substring
+ */
 extern void inquery_string_replace(inquery_string **ctx, 
         const inquery_string *what, const inquery_string *with);
 
+
+/*
+ * inquery_string_replace_first() - replace first occurrenct of substring
+ */
 extern void inquery_string_replace_first(inquery_string **ctx, 
         const inquery_string *what, const inquery_string *with);
 

--- a/lib/core/string.c
+++ b/lib/core/string.c
@@ -26,6 +26,10 @@ static void replace_first(inquery_string **h, const inquery_string *n,
     *h = s;
 }
 
+
+/*
+ * inquery_string_new() - create new string
+ */
 extern inquery_string *inquery_string_new(const char *cstr)
 {
     inquery_assert (cstr);
@@ -40,12 +44,18 @@ extern inquery_string *inquery_string_new(const char *cstr)
 }
 
 
+/*
+ * inquery_string_new_empty() - create new empty string
+ */
 extern inquery_string *inquery_string_new_empty(void)
 {
     return inquery_string_new("");
 }
 
 
+/*
+ * inquery_string_copy() - copy existing string
+ */
 extern inquery_string *inquery_string_copy(const inquery_string *ctx)
 {
     inquery_assert (ctx);
@@ -54,12 +64,18 @@ extern inquery_string *inquery_string_copy(const inquery_string *ctx)
 }
 
 
+/*
+ * inquery_string_free() - release string
+ */
 extern void inquery_string_free(inquery_string **ctx)
 {
     inquery_heap_free((void **) ctx);
 }
 
 
+/*
+ * inquery_string_len() - get length of string
+ */
 extern size_t inquery_string_len(const inquery_string *ctx)
 {
     register size_t i = 0, len = 0;
@@ -74,6 +90,9 @@ extern size_t inquery_string_len(const inquery_string *ctx)
 }
 
 
+/*
+ * inquery_string_sz() - get size of string
+ */
 extern size_t inquery_string_sz(const inquery_string *ctx)
 {
     inquery_assert (ctx);
@@ -82,6 +101,9 @@ extern size_t inquery_string_sz(const inquery_string *ctx)
 }
 
 
+/*
+ * inquery_string_cmp() - compare two strings
+ */
 extern int inquery_string_cmp(const inquery_string *lhs, 
         const inquery_string *rhs)
 {
@@ -91,18 +113,30 @@ extern int inquery_string_cmp(const inquery_string *lhs,
 }
 
 
+/*
+ * inquery_string_lt() - check if string is less than another
+ */
 extern inline bool inquery_string_lt(const inquery_string *lhs,
         const inquery_string *rhs);
 
 
+/*
+ * inquery_string_eq() - check if string is equal to another
+ */
 extern inline bool inquery_string_eq(const inquery_string *lhs,
         const inquery_string *rhs);
 
 
+/*
+ * inquery_string_gt() - check if string is greater than another
+ */
 extern inline bool inquery_string_gt(const inquery_string *lhs,
         const inquery_string *rhs);
 
 
+/*
+ * inquery_string_add() - concatenate two strings
+ */
 extern void inquery_string_add(inquery_string **ctx, const inquery_string *add)
 {
     inquery_assert (ctx && *ctx && add);
@@ -123,6 +157,9 @@ extern void inquery_string_add(inquery_string **ctx, const inquery_string *add)
 }
 
 
+/*
+ * inquery_string_find() - find first occurrence of substring
+ */
 extern size_t inquery_string_find(const inquery_string *ctx, 
         const inquery_string *what)
 {
@@ -133,6 +170,9 @@ extern size_t inquery_string_find(const inquery_string *ctx,
 }
 
 
+/*
+ * inquery_string_count() - count all occurrences of substring
+ */
 extern size_t inquery_string_count(const inquery_string *ctx,
         const inquery_string *what)
 {
@@ -150,6 +190,9 @@ extern size_t inquery_string_count(const inquery_string *ctx,
 }
 
 
+/*
+ * inquery_string_replace() - replace all occurrences of substring
+ */
 extern void inquery_string_replace(inquery_string **ctx, 
         const inquery_string *what, const inquery_string *with)
 {
@@ -174,6 +217,9 @@ extern void inquery_string_replace(inquery_string **ctx,
 }
 
 
+/*
+ * inquery_string_replace_first() - replace first occurrenct of substring
+ */
 extern void inquery_string_replace_first(inquery_string **ctx, 
         const inquery_string *what, const inquery_string *with)
 {

--- a/lib/core/string.c
+++ b/lib/core/string.c
@@ -85,7 +85,7 @@ extern size_t inquery_string_sz(const inquery_string *ctx)
 {
     inquery_assert (ctx);
 
-    return sdslen((const sds) ctx);
+    return sdslen((const sds) ctx) + 1;
 }
 
 
@@ -110,13 +110,13 @@ extern inline bool inquery_string_gt(const inquery_string *lhs,
         const inquery_string *rhs);
 
 
-extern inquery_string *inquery_string_add(const inquery_string *ctx, 
-        const inquery_string *add)
+extern void inquery_string_add(inquery_string **ctx, const inquery_string *add)
 {
-    inquery_assert (ctx && add);
+    inquery_assert (ctx && *ctx && add);
 
-    sds cp = sdsnew(ctx);
-    return sdscat(cp, add);
+    sds cp = sdsnew(*ctx);
+    sdsfree(*ctx);
+    *ctx = sdscat(cp, add);
 }
 
 

--- a/lib/core/string.c
+++ b/lib/core/string.c
@@ -1,0 +1,168 @@
+#include <string.h>
+#include "../sds/sds.h"
+#include "core.h"
+
+
+static inquery_string *replace_first(const inquery_string *h, 
+        const inquery_string *n, const inquery_string *r)
+{
+    char *pos = strstr(h, n);
+    if (!pos)
+        return inquery_string_copy(h);
+
+    const size_t hsz = sdslen((const sds) h);
+    const size_t nsz = sdslen((const sds) n);
+    const size_t rsz = sdslen((const sds) r);
+    const size_t diff = rsz - nsz;
+
+    inquery_string *s = inquery_heap_new(hsz + diff + 1);
+
+    size_t shifts = pos - h;
+    memcpy(s, h, shifts);
+    memcpy(s + shifts, r, rsz);
+    memcpy(s + shifts + rsz, pos + nsz, hsz - shifts - nsz);
+
+    s[hsz + diff] = '\0';
+    return s;
+}
+
+extern inquery_string *inquery_string_new(const char *cstr)
+{
+    inquery_assert (cstr && *cstr);
+
+    char *ctx = sdsnew(cstr);
+    inquery_require (ctx);
+
+    return ctx;
+}
+
+
+extern inquery_string *inquery_string_new_empty(void)
+{
+    char *ctx = sdsempty();
+    inquery_require (ctx);
+
+    return ctx;
+}
+
+
+extern inquery_string *inquery_string_copy(const inquery_string *ctx)
+{
+    inquery_assert (ctx);
+
+    sds cp = sdsdup((const sds) ctx);
+    inquery_require (cp);
+
+    return cp;
+}
+
+
+extern void inquery_string_free(inquery_string **ctx)
+{
+    if (inquery_likely (ctx && *ctx)) {
+        sdsfree(*ctx);
+        *ctx = NULL;
+    }
+            
+}
+
+
+extern size_t inquery_string_len(const inquery_string *ctx)
+{
+    register size_t i = 0, len = 0;
+
+    while (ctx[i]) {
+        if ((ctx[i] & 0xC0) != 0x80)
+            len++;
+        i++;
+    }
+
+    return len;
+}
+
+
+extern size_t inquery_string_sz(const inquery_string *ctx)
+{
+    inquery_assert (ctx);
+
+    return sdslen((const sds) ctx);
+}
+
+
+extern int inquery_string_cmp(const inquery_string *lhs, 
+        const inquery_string *rhs)
+{
+    inquery_assert (lhs && rhs);
+
+    return sdscmp((const sds) lhs, (const sds) rhs);
+}
+
+
+extern inline bool inquery_string_lt(const inquery_string *lhs,
+        const inquery_string *rhs);
+
+
+extern inline bool inquery_string_eq(const inquery_string *lhs,
+        const inquery_string *rhs);
+
+
+extern inline bool inquery_string_gt(const inquery_string *lhs,
+        const inquery_string *rhs);
+
+
+extern inquery_string *inquery_string_add(const inquery_string *ctx, 
+        const inquery_string *add)
+{
+    inquery_assert (ctx && add);
+
+    sds cp = sdsnew(ctx);
+    return sdscat(cp, add);
+}
+
+
+extern size_t inquery_string_find(const inquery_string *haystack, 
+        const inquery_string *needle)
+{
+    inquery_assert (haystack && needle);
+
+    inquery_string *pos = strstr(haystack, needle);
+    return pos ? inquery_string_len(haystack) - inquery_string_len(pos) + 1 : 0;
+}
+
+
+extern inquery_string *inquery_string_replace(const inquery_string *haystack, 
+        const inquery_string *needle, const inquery_string *replace)
+{
+    inquery_assert(haystack && replace && needle && *needle);
+
+    register inquery_string *r;
+    if (inquery_likely (!strstr(replace, needle))) {
+        r = replace_first(haystack, needle, replace);
+        while (strstr(r, needle))
+            r = replace_first(r, needle, replace);
+
+        return r;
+    }
+
+    const char placeholder[] = { 0x1, 0x0 };
+    r = replace_first(haystack, needle, placeholder);
+    while (strstr(r, needle))
+        r = replace_first(r, needle, placeholder);
+
+    r = replace_first(r, placeholder, replace);
+    while (strstr(r, placeholder))
+        r = replace_first(r, placeholder, replace);
+
+    return r;
+}
+
+
+extern inquery_string *inquery_string_replace_first(
+        const inquery_string *haystack, const inquery_string *needle,
+        const inquery_string *replace)
+{
+    inquery_assert(haystack && needle && *needle && replace);
+
+    return replace_first(haystack, needle, replace);
+}
+

--- a/lib/sds/LICENSE
+++ b/lib/sds/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2006-2014, Salvatore Sanfilippo <antirez at gmail dot com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/lib/sds/README.md
+++ b/lib/sds/README.md
@@ -1,0 +1,918 @@
+Simple Dynamic Strings
+===
+
+**Notes about version 2**: this is an updated version of SDS in an attempt
+to finally unify Redis, Disque, Hiredis, and the stand alone SDS versions.
+This version is **NOT* binary compatible** with SDS verison 1, but the API
+is 99% compatible so switching to the new lib should be trivial.
+
+Note that this version of SDS may be a slower with certain workloads, but
+uses less memory compared to V1 since header size is dynamic and depends to
+the string to alloc.
+
+Moreover it includes a few more API functions, notably `sdscatfmt` which
+is a faster version of `sdscatprintf` that can be used for the simpler
+cases in order to avoid the libc `printf` family functions performance
+penalty.
+
+How SDS strings work
+===
+
+SDS is a string library for C designed to augment the limited libc string
+handling functionalities by adding heap allocated strings that are:
+
+* Simpler to use.
+* Binary safe.
+* Computationally more efficient.
+* But yet... Compatible with normal C string functions.
+
+This is achieved using an alternative design in which instead of using a C
+structure to represent a string, we use a binary prefix that is stored
+before the actual pointer to the string that is returned by SDS to the user.
+
+    +--------+-------------------------------+-----------+
+    | Header | Binary safe C alike string... | Null term |
+    +--------+-------------------------------+-----------+
+             |
+             `-> Pointer returned to the user.
+
+Because of meta data stored before the actual returned pointer as a prefix,
+and because of every SDS string implicitly adding a null term at the end of
+the string regardless of the actual content of the string, SDS strings work
+well together with C strings and the user is free to use them interchangeably
+with other std C string functions that access the string in read-only.
+
+SDS was a C string I developed in the past for my everyday C programming needs,
+later it was moved into Redis where it is used extensively and where it was
+modified in order to be suitable for high performance operations. Now it was
+extracted from Redis and forked as a stand alone project.
+
+Because of its many years life inside Redis, SDS provides both higher level
+functions for easy strings manipulation in C, but also a set of low level
+functions that make it possible to write high performance code without paying
+a penalty for using an higher level string library.
+
+Advantages and disadvantages of SDS
+===
+
+Normally dynamic string libraries for C are implemented using a structure
+that defines the string. The structure has a pointer field that is managed
+by the string function, so it looks like this:
+
+```c
+struct yourAverageStringLibrary {
+    char *buf;
+    size_t len;
+    ... possibly more fields here ...
+};
+```
+
+SDS strings as already mentioned don't follow this schema, and are instead
+a single allocation with a prefix that lives *before* the address actually
+returned for the string.
+
+There are advantages and disadvantages with this approach over the traditional
+approach:
+
+**Disadvantage #1**: many functions return the new string as value, since sometimes SDS requires to create a new string with more space, so the most SDS API calls look like this:
+
+```c
+s = sdscat(s,"Some more data");
+```
+
+As you can see `s` is used as input for `sdscat` but is also set to the value
+returned by the SDS API call, since we are not sure if the call modified the
+SDS string we passed or allocated a new one. Not remembering to assign back
+the return value of `sdscat` or similar functions to the variable holding
+the SDS string will result in a bug.
+
+**Disadvantage #2**: if an SDS string is shared in different places in your program you have to modify all the references when you modify the string. However most of the times when you need to share SDS strings it is much better to encapsulate them into structures with a `reference count` otherwise it is too easy to incur into memory leaks.
+
+**Advantage #1**: you can pass SDS strings to functions designed for C functions without accessing a struct member or calling a function, like this:
+
+```c
+printf("%s\n", sds_string);
+```
+
+In most other libraries this will be something like:
+
+```c
+printf("%s\n", string->buf);
+```
+
+Or:
+
+```c
+printf("%s\n", getStringPointer(string));
+```
+
+**Advantage #2**: accessing individual chars is straightforward. C is a low level language so this is an important operation in many programs. With SDS strings accessing individual chars is very natural:
+
+```c
+printf("%c %c\n", s[0], s[1]);
+```
+
+With other libraries your best chance is to assign `string->buf` (or call the function to get the string pointer) to a `char` pointer and work with this. However since the other libraries may reallocate the buffer implicitly every time you call a function that may modify the string you have to get a reference to the buffer again.
+
+**Advantage #3**: single allocation has better cache locality. Usually when you access a string created by a string library using a structure, you have two different allocations for the structure representing the string, and the actual buffer holding the string. Over the time the buffer is reallocated, and it is likely that it ends in a totally different part of memory compared to the structure itself. Since modern programs performances are often dominated by cache misses, SDS may perform better in many workloads.
+
+SDS basics
+===
+
+The type of SDS strings is just the char pointer `char *`. However SDS defines
+an `sds` type as alias of `char *` in its header file: you should use the
+`sds` type in order to make sure you remember that a given variable in your
+program holds an SDS string and not a C string, however this is not mandatory.
+
+This is the simplest SDS program you can write that does something:
+
+```c
+sds mystring = sdsnew("Hello World!");
+printf("%s\n", mystring);
+sdsfree(mystring);
+
+output> Hello World!
+```
+
+The above small program already shows a few important things about SDS:
+
+* SDS strings are created, and heap allocated, via the `sdsnew()` function, or other similar functions that we'll see in a moment.
+* SDS strings can be passed to `printf()` like any other C string.
+* SDS strings require to be freed with `sdsfree()`, since they are heap allocated.
+
+Creating SDS strings
+---
+
+```c
+sds sdsnewlen(const void *init, size_t initlen);
+sds sdsnew(const char *init);
+sds sdsempty(void);
+sds sdsdup(const sds s);
+```
+
+There are many ways to create SDS strings:
+
+* The `sdsnew` function creates an SDS string starting from a C null terminated string. We already saw how it works in the above example.
+* The `sdsnewlen` function is similar to `sdsnew` but instead of creating the string assuming that the input string is null terminated, it gets an additional length parameter. This way you can create a string using binary data:
+
+    ```c
+    char buf[3];
+    sds mystring;
+
+    buf[0] = 'A';
+    buf[1] = 'B';
+    buf[2] = 'C';
+    mystring = sdsnewlen(buf,3);
+    printf("%s of len %d\n", mystring, (int) sdslen(mystring));
+
+    output> ABC of len 3
+    ```
+
+  Note: `sdslen` return value is casted to `int` because it returns a `size_t`
+type. You can use the right `printf` specifier instead of casting.
+
+* The `sdsempty()` function creates an empty zero-length string:
+
+    ```c
+    sds mystring = sdsempty();
+    printf("%d\n", (int) sdslen(mystring));
+
+    output> 0
+    ```
+
+* The `sdsdup()` function duplicates an already existing SDS string:
+
+    ```c
+    sds s1, s2;
+
+    s1 = sdsnew("Hello");
+    s2 = sdsdup(s1);
+    printf("%s %s\n", s1, s2);
+
+    output> Hello Hello
+    ```
+
+Obtaining the string length
+---
+
+```c
+size_t sdslen(const sds s);
+```
+
+In the examples above we already used the `sdslen` function in order to get
+the length of the string. This function works like `strlen` of the libc
+except that:
+
+* It runs in constant time since the length is stored in the prefix of SDS strings, so calling `sdslen` is not expensive even when called with very large strings.
+* The function is binary safe like any other SDS string function, so the length is the true length of the string regardless of the content, there is no problem if the string includes null term characters in the middle.
+
+As an example of the binary safeness of SDS strings, we can run the following
+code:
+
+```c
+sds s = sdsnewlen("A\0\0B",4);
+printf("%d\n", (int) sdslen(s));
+
+output> 4
+```
+
+Note that SDS strings are always null terminated at the end, so even in that
+case `s[4]` will be a null term, however printing the string with `printf`
+would result in just `"A"` to be printed since libc will treat the SDS string
+like a normal C string.
+
+Destroying strings
+---
+
+```c
+void sdsfree(sds s);
+```
+
+The destroy an SDS string there is just to call `sdsfree` with the string
+pointer. Note that even empty strings created with `sdsempty` need to be
+destroyed as well otherwise they'll result into a memory leak.
+
+The function `sdsfree` does not perform any operation if instead of an SDS
+string pointer, `NULL` is passed, so you don't need to check for `NULL` explicitly before calling it:
+
+```c
+if (string) sdsfree(string); /* Not needed. */
+sdsfree(string); /* Same effect but simpler. */
+```
+
+Concatenating strings
+---
+
+Concatenating strings to other strings is likely the operation you will end
+using the most with a dynamic C string library. SDS provides different
+functions to concatenate strings to existing strings.
+
+```c
+sds sdscatlen(sds s, const void *t, size_t len);
+sds sdscat(sds s, const char *t);
+```
+
+The main string concatenation functions are `sdscatlen` and `sdscat` that are
+identical, the only difference being that `sdscat` does not have an explicit
+length argument since it expects a null terminated string.
+
+```c
+sds s = sdsempty();
+s = sdscat(s, "Hello ");
+s = sdscat(s, "World!");
+printf("%s\n", s);
+
+output> Hello World!
+```
+
+Sometimes you want to cat an SDS string to another SDS string, so you don't
+need to specify the length, but at the same time the string does not need to
+be null terminated but can contain any binary data. For this there is a
+special function:
+
+```c
+sds sdscatsds(sds s, const sds t);
+```
+
+Usage is straightforward:
+
+```c
+sds s1 = sdsnew("aaa");
+sds s2 = sdsnew("bbb");
+s1 = sdscatsds(s1,s2);
+sdsfree(s2);
+printf("%s\n", s1);
+
+output> aaabbb
+```
+
+Sometimes you don't want to append any special data to the string, but you want
+to make sure that there are at least a given number of bytes composing the
+whole string.
+
+```c
+sds sdsgrowzero(sds s, size_t len);
+```
+
+The `sdsgrowzero` function will do nothing if the current string length is
+already `len` bytes, otherwise it will enlarge the string to `len` just padding
+it with zero bytes.
+
+```c
+sds s = sdsnew("Hello");
+s = sdsgrowzero(s,6);
+s[5] = '!'; /* We are sure this is safe because of sdsgrowzero() */
+printf("%s\n', s);
+
+output> Hello!
+```
+
+Formatting strings
+---
+
+There is a special string concatenation function that accepts a `printf` alike
+format specifier and cats the formatted string to the specified string.
+
+```c
+sds sdscatprintf(sds s, const char *fmt, ...) {
+```
+
+Example:
+
+```c
+sds s;
+int a = 10, b = 20;
+s = sdsnew("The sum is: ");
+s = sdscatprintf(s,"%d+%d = %d",a,b,a+b);
+```
+
+Often you need to create SDS string directly from `printf` format specifiers.
+Because `sdscatprintf` is actually a function that concatenates strings, all
+you need is to concatenate your string to an empty string:
+
+
+```c
+char *name = "Anna";
+int loc = 2500;
+sds s;
+s = sdscatprintf(sdsempty(), "%s wrote %d lines of LISP\n", name, loc);
+```
+
+You can use `sdscatprintf` in order to convert numbers into SDS strings:
+
+```c
+int some_integer = 100;
+sds num = sdscatprintf(sdsempty(),"%d\n", some_integer);
+```
+
+However this is slow and we have a special function to make it efficient.
+
+Fast number to string operations
+---
+
+Creating an SDS string from an integer may be a common operation in certain
+kind of programs, and while you may do this with `sdscatprintf` the performance
+hit is big, so SDS provides a specialized function.
+
+```c
+sds sdsfromlonglong(long long value);
+```
+
+Use it like this:
+
+```c
+sds s = sdsfromlonglong(10000);
+printf("%d\n", (int) sdslen(s));
+
+output> 5
+```
+
+Trimming strings and getting ranges
+---
+
+String trimming is a common operation where a set of characters are
+removed from the left and the right of the string. Another useful operation
+regarding strings is the ability to just take a range out of a larger
+string.
+
+```c
+void sdstrim(sds s, const char *cset);
+void sdsrange(sds s, int start, int end);
+```
+
+SDS provides both the operations with the `sdstrim` and `sdsrange` functions.
+However note that both functions work differently than most functions modifying
+SDS strings since the return value is void: basically those functions always
+destructively modify the passed SDS string, never allocating a new one, because
+both trimming and ranges will never need more room: the operations can only
+remove characters from the original string.
+
+Because of this behavior, both functions are fast and don't involve reallocation.
+
+This is an example of string trimming where newlines and spaces are removed
+from an SDS strings:
+
+```c
+sds s = sdsnew("         my string\n\n  ");
+sdstrim(s," \n");
+printf("-%s-\n",s);
+
+output> -my string-
+```
+
+Basically `sdstrim` takes the SDS string to trim as first argument, and a
+null terminated set of characters to remove from left and right of the string.
+The characters are removed as long as they are not interrupted by a character
+that is not in the list of characters to trim: this is why the space between
+`"my"` and `"string"` was preserved in the above example.
+
+Taking ranges is similar, but instead to take a set of characters, it takes
+to indexes, representing the start and the end as specified by zero-based
+indexes inside the string, to obtain the range that will be retained.
+
+```c
+sds s = sdsnew("Hello World!");
+sdsrange(s,1,4);
+printf("-%s-\n");
+
+output> -ello-
+```
+
+Indexes can be negative to specify a position starting from the end of the
+string, so that `-1` means the last character, `-2` the penultimate, and so forth:
+
+```c
+sds s = sdsnew("Hello World!");
+sdsrange(s,6,-1);
+printf("-%s-\n");
+sdsrange(s,0,-2);
+printf("-%s-\n");
+
+output> -World!-
+output> -World-
+```
+
+`sdsrange` is very useful when implementing networking servers processing
+a protocol or sending messages. For example the following code is used
+implementing the write handler of the Redis Cluster message bus between
+nodes:
+
+```c
+void clusterWriteHandler(..., int fd, void *privdata, ...) {
+    clusterLink *link = (clusterLink*) privdata;
+    ssize_t nwritten = write(fd, link->sndbuf, sdslen(link->sndbuf));
+    if (nwritten <= 0) {
+        /* Error handling... */
+    }
+    sdsrange(link->sndbuf,nwritten,-1);
+    ... more code here ...
+}
+```
+
+Every time the socket of the node we want to send the message to is writable
+we attempt to write as much bytes as possible, and we use `sdsrange` in order
+to remove from the buffer what was already sent.
+
+The function to queue new messages to send to some node in the cluster will
+simply use `sdscatlen` in order to put more data in the send buffer.
+
+Note that the Redis Cluster bus implements a binary protocol, but since SDS
+is binary safe this is not a problem, so the goal of SDS is not just to provide
+an high level string API for the C programmer but also dynamically allocated
+buffers that are easy to manage.
+
+String copying
+---
+
+The most dangerous and infamus function of the standard C library is probably
+`strcpy`, so perhaps it is funny how in the context of better designed dynamic
+string libraries the concept of copying strings is almost irrelevant. Usually
+what you do is to create strings with the content you want, or concatenating
+more content as needed.
+
+However SDS features a string copy function that is useful in performance
+critical code sections, however I guess its practical usefulness is limited
+as the function never managed to get called in the context of the 50k
+lines of code composing the Redis code base.
+
+```c
+sds sdscpylen(sds s, const char *t, size_t len);
+sds sdscpy(sds s, const char *t);
+```
+
+The string copy function of SDS is called `sdscpylen` and works like that:
+
+```c
+s = sdsnew("Hello World!");
+s = sdscpylen(s,"Hello Superman!",15);
+```
+
+As you can see the function receives as input the SDS string `s`, but also
+returns an SDS string. This is common to many SDS functions that modify the
+string: this way the returned SDS string may be the original one modified
+or a newly allocated one (for example if there was not enough room in the
+old SDS string).
+
+The `sdscpylen` will simply replace what was in the old SDS string with the
+new data you pass using the pointer and length argument. There is a similar
+function called `sdscpy` that does not need a length but expects a null
+terminated string instead.
+
+You may wonder why it makes sense to have a string copy function in the
+SDS library, since you can simply create a new SDS string from scratch
+with the new value instead of copying the value in an existing SDS string.
+The reason is efficiency: `sdsnewlen` will always allocate a new string
+while `sdscpylen` will try to reuse the existing string if there is enough
+room to old the new content specified by the user, and will allocate a new
+one only if needed.
+
+Quoting strings
+---
+
+In order to provide consistent output to the program user, or for debugging
+purposes, it is often important to turn a string that may contain binary
+data or special characters into a quoted string. Here for quoted string
+we mean the common format for String literals in programming source code.
+However today this format is also part of the well known serialization formats
+like JSON and CSV, so it definitely escaped the simple goal of representing
+literals strings in the source code of programs.
+
+An example of quoted string literal is the following:
+
+```c
+"\x00Hello World\n"
+```
+
+The first byte is a zero byte while the last byte is a newline, so there are
+two non alphanumerical characters inside the string.
+
+SDS uses a concatenation function for this goal, that concatenates to an
+existing string the quoted string representation of the input string.
+
+```c
+sds sdscatrepr(sds s, const char *p, size_t len);
+```
+
+The `scscatrepr` (where `repr` means *representation*) follows the usualy
+SDS string function rules accepting a char pointer and a length, so you can
+use it with SDS strings, normal C strings by using strlen() as `len` argument,
+or binary data. The following is an example usage:
+
+```c
+sds s1 = sdsnew("abcd");
+sds s2 = sdsempty();
+s[1] = 1;
+s[2] = 2;
+s[3] = '\n';
+s2 = sdscatrepr(s2,s1,sdslen(s1));
+printf("%s\n", s2);
+
+output> "a\x01\x02\n"
+```
+
+This is the rules `sdscatrepr` uses for conversion:
+
+* `\` and `"` are quoted with a backslash.
+* It quotes special characters `'\n'`, `'\r'`, `'\t'`, `'\a'` and `'\b'`.
+* All the other non printable characters not passing the `isprint` test are quoted in `\x..` form, that is: backslash followed by `x` followed by two digit hex number representing the character byte value.
+* The function always adds initial and final double quotes characters.
+
+There is an SDS function that is able to perform the reverse conversion and is
+documented in the *Tokenization* section below.
+
+Tokenization
+---
+
+Tokenization is the process of splitting a larger string into smaller strings.
+In this specific case, the split is performed specifying another string that
+acts as separator. For example in the following string there are two substrings
+that are separated by the `|-|` separator:
+
+```
+foo|-|bar|-|zap
+```
+
+A more common separator that consists of a single character is the comma:
+
+```
+foo,bar,zap
+```
+
+In many progrems it is useful to process a line in order to obtain the sub
+strings it is composed of, so SDS provides a function that returns an
+array of SDS strings given a string and a separator.
+
+```c
+sds *sdssplitlen(const char *s, int len, const char *sep, int seplen, int *count);
+void sdsfreesplitres(sds *tokens, int count);
+```
+
+As usually the function can work with both SDS strings or normal C strings.
+The first two arguments `s` and `len` specify the string to tokenize, and the
+other two arguments `sep` and `seplen` the separator to use during the
+tokenization. The final argument `count` is a pointer to an integer that will
+be set to the number of tokens (sub strings) returned.
+
+The return value is a heap allocated array of SDS strings.
+
+```c
+sds *tokens;
+int count, j;
+
+sds line = sdsnew("Hello World!");
+tokens = sdssplitlen(line,sdslen(line)," ",1,&count);
+
+for (j = 0; j < count; j++)
+    printf("%s\n", tokens[j]);
+sdsfreesplitres(tokens,count);
+
+output> Hello
+output> World!
+```
+
+The returned array is heap allocated, and the single elements of the array
+are normal SDS strings. You can free everything calling `sdsfreesplitres`
+as in the example. Alternativey you are free to release the array yourself
+using the `free` function and use and/or free the individual SDS strings
+as usually.
+
+A valid approach is to set the array elements you reused in some way to
+`NULL`, and use `sdsfreesplitres` to free all the rest.
+
+Command line oriented tokenization
+---
+
+Splitting by a separator is a useful operation, but usually it is not enough
+to perform one of the most common tasks involving some non trivial string
+manipulation, that is, implementing a **Command Line Interface** for a program.
+
+This is why SDS also provides an additional function that allows you to split
+arguments provided by the user via the keyboard in an interactive manner, or
+via a file, network, or any other mean, into tokens.
+
+```c
+sds *sdssplitargs(const char *line, int *argc);
+```
+
+The `sdssplitargs` function returns an array of SDS strings exactly like
+`sdssplitlen`. The function to free the result is also identical, and is
+`sdsfreesplitres`. The difference is in the way the tokenization is performed.
+
+For example if the input is the following line:
+
+```
+call "Sabrina"    and "Mark Smith\n"
+```
+
+The function will return the following tokens:
+
+* "call"
+* "Sabrina"
+* "and"
+* "Mark Smith\n"
+
+Basically different tokens need to be separated by one or more spaces, and
+every single token can also be a quoted string in the same format that
+`sdscatrepr` is able to emit.
+
+String joining
+---
+
+There are two functions doing the reverse of tokenization by joining strings
+into a single one.
+
+```c
+sds sdsjoin(char **argv, int argc, char *sep, size_t seplen);
+sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen);
+```
+
+The two functions take as input an array of strings of length `argc` and
+a separator and its length, and produce as output an SDS string consisting
+of all the specified strings separated by the specified separator.
+
+The difference between `sdsjoin` and `sdsjoinsds` is that the former accept
+C null terminated strings as input while the latter requires all the strings
+in the array to be SDS strings. However because of this only `sdsjoinsds` is
+able to deal with binary data.
+
+```c
+char *tokens[3] = {"foo","bar","zap"};
+sds s = sdsjoin(tokens,3,"|",1);
+printf("%s\n", s);
+
+output> foo|bar|zap
+```
+
+Error handling
+---
+
+All the SDS functions that return an SDS pointer may also return `NULL` on
+out of memory, this is basically the only check you need to perform.
+
+However many modern C programs handle out of memory simply aborting the program
+so you may want to do this as well by wrapping `malloc` and other related
+memory allocation calls directly.
+
+SDS internals and advanced usage
+===
+
+At the very beginning of this documentation it was explained how SDS strings
+are allocated, however the prefix stored before the pointer returned to the
+user was classified as an *header* without further details. For an advanced
+usage it is better to dig more into the internals of SDS and show the
+structure implementing it:
+
+```c
+struct sdshdr {
+    int len;
+    int free;
+    char buf[];
+};
+```
+
+As you can see, the structure may resemble the one of a conventional string
+library, however the `buf` field of the structure is different since it is
+not a pointer but an array without any length declared, so `buf` actually
+points at the first byte just after the `free` integer. So in order to create
+an SDS string we just allocate a piece of memory that is as large as the
+`sdshdr` structure plus the length of our string, plus an additional byte
+for the mandatory null term that every SDS string has.
+
+The `len` field of the structure is quite obvious, and is the current length
+of the SDS string, always computed every time the string is modified via
+SDS function calls. The `free` field instead represents the amount of free
+memory in the current allocation that can be used to store more characters.
+
+So the actual SDS layout is this one:
+
+    +------------+------------------------+-----------+---------------\
+    | Len | Free | H E L L O W O R L D \n | Null term |  Free space   \
+    +------------+------------------------+-----------+---------------\
+                 |
+                 `-> Pointer returned to the user.
+
+You may wonder why there is some free space at the end of the string, it
+looks like a waste. Actually after a new SDS string is created, there is no
+free space at the end at all: the allocation will be as small as possible to
+just hold the header, string, and null term. However other access patterns
+will create extra free space at the end, like in the following program:
+
+```c
+s = sdsempty();
+s = sdscat(s,"foo");
+s = sdscat(s,"bar");
+s = sdscat(s,"123");
+```
+
+Since SDS tries to be efficient it can't afford to reallocate the string every
+time new data is appended, since this would be very inefficient, so it uses
+the **preallocation of some free space** every time you enlarge the string.
+
+The preallocation algorithm used is the following: every time the string
+is reallocated in order to hold more bytes, the actual allocation size performed
+is two times the minimum required. So for instance if the string currently
+is holding 30 bytes, and we concatenate 2 more bytes, instead of allocating 32
+bytes in total SDS will allocate 64 bytes.
+
+However there is an hard limit to the allocation it can perform ahead, and is
+defined by `SDS_MAX_PREALLOC`. SDS will never allocate more than 1MB of
+additional space (by default, you can change this default).
+
+Shrinking strings
+---
+
+```c
+sds sdsRemoveFreeSpace(sds s);
+size_t sdsAllocSize(sds s);
+```
+
+Sometimes there are class of programs that require to use very little memory.
+After strings concatenations, trimming, ranges, the string may end having
+a non trivial amount of additional space at the end.
+
+It is possible to resize a string back to its minimal size in order to hold
+the current content by using the function `sdsRemoveFreeSpace`.
+
+```c
+s = sdsRemoveFreeSpace(s);
+```
+
+There is also a function that can be used in order to get the size of the
+total allocation for a given string, and is called `sdsAllocSize`.
+
+```c
+sds s = sdsnew("Ladies and gentlemen");
+s = sdscat(s,"... welcome to the C language.");
+printf("%d\n", (int) sdsAllocSize(s));
+s = sdsRemoveFreeSpace(s);
+printf("%d\n", (int) sdsAllocSize(s));
+
+output> 109
+output> 59
+```
+
+NOTE: SDS Low level API use cammelCase in order to warn you that you are playing with the fire.
+
+Manual modifications of SDS strings
+---
+
+    void sdsupdatelen(sds s);
+
+Sometimes you may want to hack with an SDS string manually, without using
+SDS functions. In the following example we implicitly change the length
+of the string, however we want the logical length to reflect the null terminated
+C string.
+
+The function `sdsupdatelen` does just that, updating the internal length
+information for the specified string to the length obtained via `strlen`.
+
+```c
+sds s = sdsnew("foobar");
+s[2] = '\0';
+printf("%d\n", sdslen(s));
+sdsupdatelen(s);
+printf("%d\n", sdslen(s));
+
+output> 6
+output> 2
+```
+
+Sharing SDS strings
+---
+
+If you are writing a program in which it is advantageous to share the same
+SDS string across different data structures, it is absolutely advised to
+encapsulate SDS strings into structures that remember the number of references
+of the string, with functions to increment and decrement the number of references.
+
+This approach is a memory management technique called *reference counting* and
+in the context of SDS has two advantages:
+
+* It is less likely that you'll create memory leaks or bugs due to non freeing SDS strings or freeing already freed strings.
+* You'll not need to update every reference to an SDS string when you modify it (since the new SDS string may point to a different memory location).
+
+While this is definitely a very common programming technique I'll outline
+the basic ideas here. You create a structure like that:
+
+```c
+struct mySharedString {
+    int refcount;
+    sds string;
+}
+```
+
+When new strings are created, the structure is allocated and returned with
+`refcount` set to 1. The you have two functions to change the reference count
+of the shared string:
+
+* `incrementStringRefCount` will simply increment `refcount` of 1 in the structure. It will be called every time you add a reference to the string on some new data structure, variable, or whatever.
+* `decrementStringRefCount` is used when you remove a reference. This function is however special since when the `refcount` drops to zero, it automatically frees the SDS string, and the `mySharedString` structure as well.
+
+Interactions with heap checkers
+---
+
+Because SDS returns pointers into the middle of memory chunks allocated with
+`malloc`, heap checkers may have issues, however:
+
+* The popular Valgrind program will detect SDS strings are *possibly lost* memory and never as *definitely lost*, so it is easy to tell if there is a leak or not. I used Valgrind with Redis for years and every real leak was consistently detected as "definitely lost".
+* OSX instrumentation tools don't detect SDS strings as leaks but are able to correctly handle pointers pointing to the middle of memory chunks.
+
+Zero copy append from syscalls
+----
+
+At this point you should have all the tools to dig more inside the SDS
+library by reading the source code, however there is an interesting pattern
+you can mount using the low level API exported, that is used inside Redis
+in order to improve performances of the networking code.
+
+Using `sdsIncrLen()` and `sdsMakeRoomFor()` it is possible to mount the
+following schema, to cat bytes coming from the kernel to the end of an
+sds string without copying into an intermediate buffer:
+
+```c
+oldlen = sdslen(s);
+s = sdsMakeRoomFor(s, BUFFER_SIZE);
+nread = read(fd, s+oldlen, BUFFER_SIZE);
+... check for nread <= 0 and handle it ...
+sdsIncrLen(s, nread);
+```
+
+`sdsIncrLen` is documented inside the source code of `sds.c`.
+
+Embedding SDS into your project
+===
+
+This is as simple as copying the following files inside your
+project:
+
+* sds.c
+* sds.h
+* sdsalloc.h
+
+The source code is small and every C99 compiler should deal with
+it without issues.
+
+Using a different allocator for SDS
+===
+
+Internally sds.c uses the allocator defined into `sdsalloc.h`. This header
+file just defines macros for malloc, realloc and free, and by default libc
+`malloc()`, `realloc()` and `free()` are used. Just edit this file in order
+to change the name of the allocation functions.
+
+The program using SDS can call the SDS allocator in order to manipulate
+SDS pointers (usually not needed but sometimes the program may want to
+do advanced things) by using the API exported by SDS in order to call the
+allocator used. This is especially useful when the program linked to SDS
+is using a different allocator compared to what SDS is using.
+
+The API to access the allocator used by SDS is composed of three functions: `sds_malloc()`, `sds_realloc()` and `sds_free()`.
+
+Credits and license
+===
+
+SDS was created by Salvatore Sanfilippo and is released under the BDS two clause license. See the LICENSE file in this source distribution for more information.
+
+Oran Agra improved SDS version 2 by adding dynamic sized headers in order to
+save memory for small strings and allow strings greater than 4GB.
+

--- a/lib/sds/sds.c
+++ b/lib/sds/sds.c
@@ -1,0 +1,1301 @@
+/* SDSLib 2.0 -- A C dynamic strings library
+ *
+ * Copyright (c) 2006-2015, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2015, Oran Agra
+ * Copyright (c) 2015, Redis Labs, Inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <assert.h>
+#include <limits.h>
+#include "sds.h"
+#include "sdsalloc.h"
+
+const char *SDS_NOINIT = "SDS_NOINIT";
+
+static inline int sdsHdrSize(char type) {
+    switch(type&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            return sizeof(struct sdshdr5);
+        case SDS_TYPE_8:
+            return sizeof(struct sdshdr8);
+        case SDS_TYPE_16:
+            return sizeof(struct sdshdr16);
+        case SDS_TYPE_32:
+            return sizeof(struct sdshdr32);
+        case SDS_TYPE_64:
+            return sizeof(struct sdshdr64);
+    }
+    return 0;
+}
+
+static inline char sdsReqType(size_t string_size) {
+    if (string_size < 1<<5)
+        return SDS_TYPE_5;
+    if (string_size < 1<<8)
+        return SDS_TYPE_8;
+    if (string_size < 1<<16)
+        return SDS_TYPE_16;
+#if (LONG_MAX == LLONG_MAX)
+    if (string_size < 1ll<<32)
+        return SDS_TYPE_32;
+    return SDS_TYPE_64;
+#else
+    return SDS_TYPE_32;
+#endif
+}
+
+/* Create a new sds string with the content specified by the 'init' pointer
+ * and 'initlen'.
+ * If NULL is used for 'init' the string is initialized with zero bytes.
+ * If SDS_NOINIT is used, the buffer is left uninitialized;
+ *
+ * The string is always null-termined (all the sds strings are, always) so
+ * even if you create an sds string with:
+ *
+ * mystring = sdsnewlen("abc",3);
+ *
+ * You can print the string with printf() as there is an implicit \0 at the
+ * end of the string. However the string is binary safe and can contain
+ * \0 characters in the middle, as the length is stored in the sds header. */
+sds sdsnewlen(const void *init, size_t initlen) {
+    void *sh;
+    sds s;
+    char type = sdsReqType(initlen);
+    /* Empty strings are usually created in order to append. Use type 8
+     * since type 5 is not good at this. */
+    if (type == SDS_TYPE_5 && initlen == 0) type = SDS_TYPE_8;
+    int hdrlen = sdsHdrSize(type);
+    unsigned char *fp; /* flags pointer. */
+
+    sh = s_malloc(hdrlen+initlen+1);
+    if (sh == NULL) return NULL;
+    if (init==SDS_NOINIT)
+        init = NULL;
+    else if (!init)
+        memset(sh, 0, hdrlen+initlen+1);
+    s = (char*)sh+hdrlen;
+    fp = ((unsigned char*)s)-1;
+    switch(type) {
+        case SDS_TYPE_5: {
+            *fp = type | (initlen << SDS_TYPE_BITS);
+            break;
+        }
+        case SDS_TYPE_8: {
+            SDS_HDR_VAR(8,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+        case SDS_TYPE_16: {
+            SDS_HDR_VAR(16,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+        case SDS_TYPE_32: {
+            SDS_HDR_VAR(32,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+        case SDS_TYPE_64: {
+            SDS_HDR_VAR(64,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+    }
+    if (initlen && init)
+        memcpy(s, init, initlen);
+    s[initlen] = '\0';
+    return s;
+}
+
+/* Create an empty (zero length) sds string. Even in this case the string
+ * always has an implicit null term. */
+sds sdsempty(void) {
+    return sdsnewlen("",0);
+}
+
+/* Create a new sds string starting from a null terminated C string. */
+sds sdsnew(const char *init) {
+    size_t initlen = (init == NULL) ? 0 : strlen(init);
+    return sdsnewlen(init, initlen);
+}
+
+/* Duplicate an sds string. */
+sds sdsdup(const sds s) {
+    return sdsnewlen(s, sdslen(s));
+}
+
+/* Free an sds string. No operation is performed if 's' is NULL. */
+void sdsfree(sds s) {
+    if (s == NULL) return;
+    s_free((char*)s-sdsHdrSize(s[-1]));
+}
+
+/* Set the sds string length to the length as obtained with strlen(), so
+ * considering as content only up to the first null term character.
+ *
+ * This function is useful when the sds string is hacked manually in some
+ * way, like in the following example:
+ *
+ * s = sdsnew("foobar");
+ * s[2] = '\0';
+ * sdsupdatelen(s);
+ * printf("%d\n", sdslen(s));
+ *
+ * The output will be "2", but if we comment out the call to sdsupdatelen()
+ * the output will be "6" as the string was modified but the logical length
+ * remains 6 bytes. */
+void sdsupdatelen(sds s) {
+    size_t reallen = strlen(s);
+    sdssetlen(s, reallen);
+}
+
+/* Modify an sds string in-place to make it empty (zero length).
+ * However all the existing buffer is not discarded but set as free space
+ * so that next append operations will not require allocations up to the
+ * number of bytes previously available. */
+void sdsclear(sds s) {
+    sdssetlen(s, 0);
+    s[0] = '\0';
+}
+
+/* Enlarge the free space at the end of the sds string so that the caller
+ * is sure that after calling this function can overwrite up to addlen
+ * bytes after the end of the string, plus one more byte for nul term.
+ *
+ * Note: this does not change the *length* of the sds string as returned
+ * by sdslen(), but only the free buffer space we have. */
+sds sdsMakeRoomFor(sds s, size_t addlen) {
+    void *sh, *newsh;
+    size_t avail = sdsavail(s);
+    size_t len, newlen;
+    char type, oldtype = s[-1] & SDS_TYPE_MASK;
+    int hdrlen;
+
+    /* Return ASAP if there is enough space left. */
+    if (avail >= addlen) return s;
+
+    len = sdslen(s);
+    sh = (char*)s-sdsHdrSize(oldtype);
+    newlen = (len+addlen);
+    if (newlen < SDS_MAX_PREALLOC)
+        newlen *= 2;
+    else
+        newlen += SDS_MAX_PREALLOC;
+
+    type = sdsReqType(newlen);
+
+    /* Don't use type 5: the user is appending to the string and type 5 is
+     * not able to remember empty space, so sdsMakeRoomFor() must be called
+     * at every appending operation. */
+    if (type == SDS_TYPE_5) type = SDS_TYPE_8;
+
+    hdrlen = sdsHdrSize(type);
+    if (oldtype==type) {
+        newsh = s_realloc(sh, hdrlen+newlen+1);
+        if (newsh == NULL) return NULL;
+        s = (char*)newsh+hdrlen;
+    } else {
+        /* Since the header size changes, need to move the string forward,
+         * and can't use realloc */
+        newsh = s_malloc(hdrlen+newlen+1);
+        if (newsh == NULL) return NULL;
+        memcpy((char*)newsh+hdrlen, s, len+1);
+        s_free(sh);
+        s = (char*)newsh+hdrlen;
+        s[-1] = type;
+        sdssetlen(s, len);
+    }
+    sdssetalloc(s, newlen);
+    return s;
+}
+
+/* Reallocate the sds string so that it has no free space at the end. The
+ * contained string remains not altered, but next concatenation operations
+ * will require a reallocation.
+ *
+ * After the call, the passed sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdsRemoveFreeSpace(sds s) {
+    void *sh, *newsh;
+    char type, oldtype = s[-1] & SDS_TYPE_MASK;
+    int hdrlen, oldhdrlen = sdsHdrSize(oldtype);
+    size_t len = sdslen(s);
+    size_t avail = sdsavail(s);
+    sh = (char*)s-oldhdrlen;
+
+    /* Return ASAP if there is no space left. */
+    if (avail == 0) return s;
+
+    /* Check what would be the minimum SDS header that is just good enough to
+     * fit this string. */
+    type = sdsReqType(len);
+    hdrlen = sdsHdrSize(type);
+
+    /* If the type is the same, or at least a large enough type is still
+     * required, we just realloc(), letting the allocator to do the copy
+     * only if really needed. Otherwise if the change is huge, we manually
+     * reallocate the string to use the different header type. */
+    if (oldtype==type || type > SDS_TYPE_8) {
+        newsh = s_realloc(sh, oldhdrlen+len+1);
+        if (newsh == NULL) return NULL;
+        s = (char*)newsh+oldhdrlen;
+    } else {
+        newsh = s_malloc(hdrlen+len+1);
+        if (newsh == NULL) return NULL;
+        memcpy((char*)newsh+hdrlen, s, len+1);
+        s_free(sh);
+        s = (char*)newsh+hdrlen;
+        s[-1] = type;
+        sdssetlen(s, len);
+    }
+    sdssetalloc(s, len);
+    return s;
+}
+
+/* Return the total size of the allocation of the specified sds string,
+ * including:
+ * 1) The sds header before the pointer.
+ * 2) The string.
+ * 3) The free buffer at the end if any.
+ * 4) The implicit null term.
+ */
+size_t sdsAllocSize(sds s) {
+    size_t alloc = sdsalloc(s);
+    return sdsHdrSize(s[-1])+alloc+1;
+}
+
+/* Return the pointer of the actual SDS allocation (normally SDS strings
+ * are referenced by the start of the string buffer). */
+void *sdsAllocPtr(sds s) {
+    return (void*) (s-sdsHdrSize(s[-1]));
+}
+
+/* Increment the sds length and decrements the left free space at the
+ * end of the string according to 'incr'. Also set the null term
+ * in the new end of the string.
+ *
+ * This function is used in order to fix the string length after the
+ * user calls sdsMakeRoomFor(), writes something after the end of
+ * the current string, and finally needs to set the new length.
+ *
+ * Note: it is possible to use a negative increment in order to
+ * right-trim the string.
+ *
+ * Usage example:
+ *
+ * Using sdsIncrLen() and sdsMakeRoomFor() it is possible to mount the
+ * following schema, to cat bytes coming from the kernel to the end of an
+ * sds string without copying into an intermediate buffer:
+ *
+ * oldlen = sdslen(s);
+ * s = sdsMakeRoomFor(s, BUFFER_SIZE);
+ * nread = read(fd, s+oldlen, BUFFER_SIZE);
+ * ... check for nread <= 0 and handle it ...
+ * sdsIncrLen(s, nread);
+ */
+void sdsIncrLen(sds s, ssize_t incr) {
+    unsigned char flags = s[-1];
+    size_t len;
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5: {
+            unsigned char *fp = ((unsigned char*)s)-1;
+            unsigned char oldlen = SDS_TYPE_5_LEN(flags);
+            assert((incr > 0 && oldlen+incr < 32) || (incr < 0 && oldlen >= (unsigned int)(-incr)));
+            *fp = SDS_TYPE_5 | ((oldlen+incr) << SDS_TYPE_BITS);
+            len = oldlen+incr;
+            break;
+        }
+        case SDS_TYPE_8: {
+            SDS_HDR_VAR(8,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= incr) || (incr < 0 && sh->len >= (unsigned int)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        case SDS_TYPE_16: {
+            SDS_HDR_VAR(16,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= incr) || (incr < 0 && sh->len >= (unsigned int)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        case SDS_TYPE_32: {
+            SDS_HDR_VAR(32,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= (unsigned int)incr) || (incr < 0 && sh->len >= (unsigned int)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        case SDS_TYPE_64: {
+            SDS_HDR_VAR(64,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= (uint64_t)incr) || (incr < 0 && sh->len >= (uint64_t)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        default: len = 0; /* Just to avoid compilation warnings. */
+    }
+    s[len] = '\0';
+}
+
+/* Grow the sds to have the specified length. Bytes that were not part of
+ * the original length of the sds will be set to zero.
+ *
+ * if the specified length is smaller than the current length, no operation
+ * is performed. */
+sds sdsgrowzero(sds s, size_t len) {
+    size_t curlen = sdslen(s);
+
+    if (len <= curlen) return s;
+    s = sdsMakeRoomFor(s,len-curlen);
+    if (s == NULL) return NULL;
+
+    /* Make sure added region doesn't contain garbage */
+    memset(s+curlen,0,(len-curlen+1)); /* also set trailing \0 byte */
+    sdssetlen(s, len);
+    return s;
+}
+
+/* Append the specified binary-safe string pointed by 't' of 'len' bytes to the
+ * end of the specified sds string 's'.
+ *
+ * After the call, the passed sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscatlen(sds s, const void *t, size_t len) {
+    size_t curlen = sdslen(s);
+
+    s = sdsMakeRoomFor(s,len);
+    if (s == NULL) return NULL;
+    memcpy(s+curlen, t, len);
+    sdssetlen(s, curlen+len);
+    s[curlen+len] = '\0';
+    return s;
+}
+
+/* Append the specified null termianted C string to the sds string 's'.
+ *
+ * After the call, the passed sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscat(sds s, const char *t) {
+    return sdscatlen(s, t, strlen(t));
+}
+
+/* Append the specified sds 't' to the existing sds 's'.
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscatsds(sds s, const sds t) {
+    return sdscatlen(s, t, sdslen(t));
+}
+
+/* Destructively modify the sds string 's' to hold the specified binary
+ * safe string pointed by 't' of length 'len' bytes. */
+sds sdscpylen(sds s, const char *t, size_t len) {
+    if (sdsalloc(s) < len) {
+        s = sdsMakeRoomFor(s,len-sdslen(s));
+        if (s == NULL) return NULL;
+    }
+    memcpy(s, t, len);
+    s[len] = '\0';
+    sdssetlen(s, len);
+    return s;
+}
+
+/* Like sdscpylen() but 't' must be a null-termined string so that the length
+ * of the string is obtained with strlen(). */
+sds sdscpy(sds s, const char *t) {
+    return sdscpylen(s, t, strlen(t));
+}
+
+/* Helper for sdscatlonglong() doing the actual number -> string
+ * conversion. 's' must point to a string with room for at least
+ * SDS_LLSTR_SIZE bytes.
+ *
+ * The function returns the length of the null-terminated string
+ * representation stored at 's'. */
+#define SDS_LLSTR_SIZE 21
+int sdsll2str(char *s, long long value) {
+    char *p, aux;
+    unsigned long long v;
+    size_t l;
+
+    /* Generate the string representation, this method produces
+     * an reversed string. */
+    v = (value < 0) ? -value : value;
+    p = s;
+    do {
+        *p++ = '0'+(v%10);
+        v /= 10;
+    } while(v);
+    if (value < 0) *p++ = '-';
+
+    /* Compute length and add null term. */
+    l = p-s;
+    *p = '\0';
+
+    /* Reverse the string. */
+    p--;
+    while(s < p) {
+        aux = *s;
+        *s = *p;
+        *p = aux;
+        s++;
+        p--;
+    }
+    return l;
+}
+
+/* Identical sdsll2str(), but for unsigned long long type. */
+int sdsull2str(char *s, unsigned long long v) {
+    char *p, aux;
+    size_t l;
+
+    /* Generate the string representation, this method produces
+     * an reversed string. */
+    p = s;
+    do {
+        *p++ = '0'+(v%10);
+        v /= 10;
+    } while(v);
+
+    /* Compute length and add null term. */
+    l = p-s;
+    *p = '\0';
+
+    /* Reverse the string. */
+    p--;
+    while(s < p) {
+        aux = *s;
+        *s = *p;
+        *p = aux;
+        s++;
+        p--;
+    }
+    return l;
+}
+
+/* Create an sds string from a long long value. It is much faster than:
+ *
+ * sdscatprintf(sdsempty(),"%lld\n", value);
+ */
+sds sdsfromlonglong(long long value) {
+    char buf[SDS_LLSTR_SIZE];
+    int len = sdsll2str(buf,value);
+
+    return sdsnewlen(buf,len);
+}
+
+/* Like sdscatprintf() but gets va_list instead of being variadic. */
+sds sdscatvprintf(sds s, const char *fmt, va_list ap) {
+    va_list cpy;
+    char staticbuf[1024], *buf = staticbuf, *t;
+    size_t buflen = strlen(fmt)*2;
+
+    /* We try to start using a static buffer for speed.
+     * If not possible we revert to heap allocation. */
+    if (buflen > sizeof(staticbuf)) {
+        buf = s_malloc(buflen);
+        if (buf == NULL) return NULL;
+    } else {
+        buflen = sizeof(staticbuf);
+    }
+
+    /* Try with buffers two times bigger every time we fail to
+     * fit the string in the current buffer size. */
+    while(1) {
+        buf[buflen-2] = '\0';
+        va_copy(cpy,ap);
+        vsnprintf(buf, buflen, fmt, cpy);
+        va_end(cpy);
+        if (buf[buflen-2] != '\0') {
+            if (buf != staticbuf) s_free(buf);
+            buflen *= 2;
+            buf = s_malloc(buflen);
+            if (buf == NULL) return NULL;
+            continue;
+        }
+        break;
+    }
+
+    /* Finally concat the obtained string to the SDS string and return it. */
+    t = sdscat(s, buf);
+    if (buf != staticbuf) s_free(buf);
+    return t;
+}
+
+/* Append to the sds string 's' a string obtained using printf-alike format
+ * specifier.
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call.
+ *
+ * Example:
+ *
+ * s = sdsnew("Sum is: ");
+ * s = sdscatprintf(s,"%d+%d = %d",a,b,a+b).
+ *
+ * Often you need to create a string from scratch with the printf-alike
+ * format. When this is the need, just use sdsempty() as the target string:
+ *
+ * s = sdscatprintf(sdsempty(), "... your format ...", args);
+ */
+sds sdscatprintf(sds s, const char *fmt, ...) {
+    va_list ap;
+    char *t;
+    va_start(ap, fmt);
+    t = sdscatvprintf(s,fmt,ap);
+    va_end(ap);
+    return t;
+}
+
+/* This function is similar to sdscatprintf, but much faster as it does
+ * not rely on sprintf() family functions implemented by the libc that
+ * are often very slow. Moreover directly handling the sds string as
+ * new data is concatenated provides a performance improvement.
+ *
+ * However this function only handles an incompatible subset of printf-alike
+ * format specifiers:
+ *
+ * %s - C String
+ * %S - SDS string
+ * %i - signed int
+ * %I - 64 bit signed integer (long long, int64_t)
+ * %u - unsigned int
+ * %U - 64 bit unsigned integer (unsigned long long, uint64_t)
+ * %% - Verbatim "%" character.
+ */
+sds sdscatfmt(sds s, char const *fmt, ...) {
+    size_t initlen = sdslen(s);
+    const char *f = fmt;
+    long i;
+    va_list ap;
+
+    /* To avoid continuous reallocations, let's start with a buffer that
+     * can hold at least two times the format string itself. It's not the
+     * best heuristic but seems to work in practice. */
+    s = sdsMakeRoomFor(s, initlen + strlen(fmt)*2);
+    va_start(ap,fmt);
+    f = fmt;    /* Next format specifier byte to process. */
+    i = initlen; /* Position of the next byte to write to dest str. */
+    while(*f) {
+        char next, *str;
+        size_t l;
+        long long num;
+        unsigned long long unum;
+
+        /* Make sure there is always space for at least 1 char. */
+        if (sdsavail(s)==0) {
+            s = sdsMakeRoomFor(s,1);
+        }
+
+        switch(*f) {
+        case '%':
+            next = *(f+1);
+            f++;
+            switch(next) {
+            case 's':
+            case 'S':
+                str = va_arg(ap,char*);
+                l = (next == 's') ? strlen(str) : sdslen(str);
+                if (sdsavail(s) < l) {
+                    s = sdsMakeRoomFor(s,l);
+                }
+                memcpy(s+i,str,l);
+                sdsinclen(s,l);
+                i += l;
+                break;
+            case 'i':
+            case 'I':
+                if (next == 'i')
+                    num = va_arg(ap,int);
+                else
+                    num = va_arg(ap,long long);
+                {
+                    char buf[SDS_LLSTR_SIZE];
+                    l = sdsll2str(buf,num);
+                    if (sdsavail(s) < l) {
+                        s = sdsMakeRoomFor(s,l);
+                    }
+                    memcpy(s+i,buf,l);
+                    sdsinclen(s,l);
+                    i += l;
+                }
+                break;
+            case 'u':
+            case 'U':
+                if (next == 'u')
+                    unum = va_arg(ap,unsigned int);
+                else
+                    unum = va_arg(ap,unsigned long long);
+                {
+                    char buf[SDS_LLSTR_SIZE];
+                    l = sdsull2str(buf,unum);
+                    if (sdsavail(s) < l) {
+                        s = sdsMakeRoomFor(s,l);
+                    }
+                    memcpy(s+i,buf,l);
+                    sdsinclen(s,l);
+                    i += l;
+                }
+                break;
+            default: /* Handle %% and generally %<unknown>. */
+                s[i++] = next;
+                sdsinclen(s,1);
+                break;
+            }
+            break;
+        default:
+            s[i++] = *f;
+            sdsinclen(s,1);
+            break;
+        }
+        f++;
+    }
+    va_end(ap);
+
+    /* Add null-term */
+    s[i] = '\0';
+    return s;
+}
+
+/* Remove the part of the string from left and from right composed just of
+ * contiguous characters found in 'cset', that is a null terminted C string.
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call.
+ *
+ * Example:
+ *
+ * s = sdsnew("AA...AA.a.aa.aHelloWorld     :::");
+ * s = sdstrim(s,"Aa. :");
+ * printf("%s\n", s);
+ *
+ * Output will be just "HelloWorld".
+ */
+sds sdstrim(sds s, const char *cset) {
+    char *start, *end, *sp, *ep;
+    size_t len;
+
+    sp = start = s;
+    ep = end = s+sdslen(s)-1;
+    while(sp <= end && strchr(cset, *sp)) sp++;
+    while(ep > sp && strchr(cset, *ep)) ep--;
+    len = (sp > ep) ? 0 : ((ep-sp)+1);
+    if (s != sp) memmove(s, sp, len);
+    s[len] = '\0';
+    sdssetlen(s,len);
+    return s;
+}
+
+/* Turn the string into a smaller (or equal) string containing only the
+ * substring specified by the 'start' and 'end' indexes.
+ *
+ * start and end can be negative, where -1 means the last character of the
+ * string, -2 the penultimate character, and so forth.
+ *
+ * The interval is inclusive, so the start and end characters will be part
+ * of the resulting string.
+ *
+ * The string is modified in-place.
+ *
+ * Example:
+ *
+ * s = sdsnew("Hello World");
+ * sdsrange(s,1,-1); => "ello World"
+ */
+void sdsrange(sds s, ssize_t start, ssize_t end) {
+    size_t newlen, len = sdslen(s);
+
+    if (len == 0) return;
+    if (start < 0) {
+        start = len+start;
+        if (start < 0) start = 0;
+    }
+    if (end < 0) {
+        end = len+end;
+        if (end < 0) end = 0;
+    }
+    newlen = (start > end) ? 0 : (end-start)+1;
+    if (newlen != 0) {
+        if (start >= (ssize_t)len) {
+            newlen = 0;
+        } else if (end >= (ssize_t)len) {
+            end = len-1;
+            newlen = (start > end) ? 0 : (end-start)+1;
+        }
+    } else {
+        start = 0;
+    }
+    if (start && newlen) memmove(s, s+start, newlen);
+    s[newlen] = 0;
+    sdssetlen(s,newlen);
+}
+
+/* Apply tolower() to every character of the sds string 's'. */
+void sdstolower(sds s) {
+    size_t len = sdslen(s), j;
+
+    for (j = 0; j < len; j++) s[j] = tolower(s[j]);
+}
+
+/* Apply toupper() to every character of the sds string 's'. */
+void sdstoupper(sds s) {
+    size_t len = sdslen(s), j;
+
+    for (j = 0; j < len; j++) s[j] = toupper(s[j]);
+}
+
+/* Compare two sds strings s1 and s2 with memcmp().
+ *
+ * Return value:
+ *
+ *     positive if s1 > s2.
+ *     negative if s1 < s2.
+ *     0 if s1 and s2 are exactly the same binary string.
+ *
+ * If two strings share exactly the same prefix, but one of the two has
+ * additional characters, the longer string is considered to be greater than
+ * the smaller one. */
+int sdscmp(const sds s1, const sds s2) {
+    size_t l1, l2, minlen;
+    int cmp;
+
+    l1 = sdslen(s1);
+    l2 = sdslen(s2);
+    minlen = (l1 < l2) ? l1 : l2;
+    cmp = memcmp(s1,s2,minlen);
+    if (cmp == 0) return l1>l2? 1: (l1<l2? -1: 0);
+    return cmp;
+}
+
+/* Split 's' with separator in 'sep'. An array
+ * of sds strings is returned. *count will be set
+ * by reference to the number of tokens returned.
+ *
+ * On out of memory, zero length string, zero length
+ * separator, NULL is returned.
+ *
+ * Note that 'sep' is able to split a string using
+ * a multi-character separator. For example
+ * sdssplit("foo_-_bar","_-_"); will return two
+ * elements "foo" and "bar".
+ *
+ * This version of the function is binary-safe but
+ * requires length arguments. sdssplit() is just the
+ * same function but for zero-terminated strings.
+ */
+sds *sdssplitlen(const char *s, ssize_t len, const char *sep, int seplen, int *count) {
+    int elements = 0, slots = 5;
+    long start = 0, j;
+    sds *tokens;
+
+    if (seplen < 1 || len < 0) return NULL;
+
+    tokens = s_malloc(sizeof(sds)*slots);
+    if (tokens == NULL) return NULL;
+
+    if (len == 0) {
+        *count = 0;
+        return tokens;
+    }
+    for (j = 0; j < (len-(seplen-1)); j++) {
+        /* make sure there is room for the next element and the final one */
+        if (slots < elements+2) {
+            sds *newtokens;
+
+            slots *= 2;
+            newtokens = s_realloc(tokens,sizeof(sds)*slots);
+            if (newtokens == NULL) goto cleanup;
+            tokens = newtokens;
+        }
+        /* search the separator */
+        if ((seplen == 1 && *(s+j) == sep[0]) || (memcmp(s+j,sep,seplen) == 0)) {
+            tokens[elements] = sdsnewlen(s+start,j-start);
+            if (tokens[elements] == NULL) goto cleanup;
+            elements++;
+            start = j+seplen;
+            j = j+seplen-1; /* skip the separator */
+        }
+    }
+    /* Add the final element. We are sure there is room in the tokens array. */
+    tokens[elements] = sdsnewlen(s+start,len-start);
+    if (tokens[elements] == NULL) goto cleanup;
+    elements++;
+    *count = elements;
+    return tokens;
+
+cleanup:
+    {
+        int i;
+        for (i = 0; i < elements; i++) sdsfree(tokens[i]);
+        s_free(tokens);
+        *count = 0;
+        return NULL;
+    }
+}
+
+/* Free the result returned by sdssplitlen(), or do nothing if 'tokens' is NULL. */
+void sdsfreesplitres(sds *tokens, int count) {
+    if (!tokens) return;
+    while(count--)
+        sdsfree(tokens[count]);
+    s_free(tokens);
+}
+
+/* Append to the sds string "s" an escaped string representation where
+ * all the non-printable characters (tested with isprint()) are turned into
+ * escapes in the form "\n\r\a...." or "\x<hex-number>".
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscatrepr(sds s, const char *p, size_t len) {
+    s = sdscatlen(s,"\"",1);
+    while(len--) {
+        switch(*p) {
+        case '\\':
+        case '"':
+            s = sdscatprintf(s,"\\%c",*p);
+            break;
+        case '\n': s = sdscatlen(s,"\\n",2); break;
+        case '\r': s = sdscatlen(s,"\\r",2); break;
+        case '\t': s = sdscatlen(s,"\\t",2); break;
+        case '\a': s = sdscatlen(s,"\\a",2); break;
+        case '\b': s = sdscatlen(s,"\\b",2); break;
+        default:
+            if (isprint(*p))
+                s = sdscatprintf(s,"%c",*p);
+            else
+                s = sdscatprintf(s,"\\x%02x",(unsigned char)*p);
+            break;
+        }
+        p++;
+    }
+    return sdscatlen(s,"\"",1);
+}
+
+/* Helper function for sdssplitargs() that returns non zero if 'c'
+ * is a valid hex digit. */
+int is_hex_digit(char c) {
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
+           (c >= 'A' && c <= 'F');
+}
+
+/* Helper function for sdssplitargs() that converts a hex digit into an
+ * integer from 0 to 15 */
+int hex_digit_to_int(char c) {
+    switch(c) {
+    case '0': return 0;
+    case '1': return 1;
+    case '2': return 2;
+    case '3': return 3;
+    case '4': return 4;
+    case '5': return 5;
+    case '6': return 6;
+    case '7': return 7;
+    case '8': return 8;
+    case '9': return 9;
+    case 'a': case 'A': return 10;
+    case 'b': case 'B': return 11;
+    case 'c': case 'C': return 12;
+    case 'd': case 'D': return 13;
+    case 'e': case 'E': return 14;
+    case 'f': case 'F': return 15;
+    default: return 0;
+    }
+}
+
+/* Split a line into arguments, where every argument can be in the
+ * following programming-language REPL-alike form:
+ *
+ * foo bar "newline are supported\n" and "\xff\x00otherstuff"
+ *
+ * The number of arguments is stored into *argc, and an array
+ * of sds is returned.
+ *
+ * The caller should free the resulting array of sds strings with
+ * sdsfreesplitres().
+ *
+ * Note that sdscatrepr() is able to convert back a string into
+ * a quoted string in the same format sdssplitargs() is able to parse.
+ *
+ * The function returns the allocated tokens on success, even when the
+ * input string is empty, or NULL if the input contains unbalanced
+ * quotes or closed quotes followed by non space characters
+ * as in: "foo"bar or "foo'
+ */
+sds *sdssplitargs(const char *line, int *argc) {
+    const char *p = line;
+    char *current = NULL;
+    char **vector = NULL;
+
+    *argc = 0;
+    while(1) {
+        /* skip blanks */
+        while(*p && isspace(*p)) p++;
+        if (*p) {
+            /* get a token */
+            int inq=0;  /* set to 1 if we are in "quotes" */
+            int insq=0; /* set to 1 if we are in 'single quotes' */
+            int done=0;
+
+            if (current == NULL) current = sdsempty();
+            while(!done) {
+                if (inq) {
+                    if (*p == '\\' && *(p+1) == 'x' &&
+                                             is_hex_digit(*(p+2)) &&
+                                             is_hex_digit(*(p+3)))
+                    {
+                        unsigned char byte;
+
+                        byte = (hex_digit_to_int(*(p+2))*16)+
+                                hex_digit_to_int(*(p+3));
+                        current = sdscatlen(current,(char*)&byte,1);
+                        p += 3;
+                    } else if (*p == '\\' && *(p+1)) {
+                        char c;
+
+                        p++;
+                        switch(*p) {
+                        case 'n': c = '\n'; break;
+                        case 'r': c = '\r'; break;
+                        case 't': c = '\t'; break;
+                        case 'b': c = '\b'; break;
+                        case 'a': c = '\a'; break;
+                        default: c = *p; break;
+                        }
+                        current = sdscatlen(current,&c,1);
+                    } else if (*p == '"') {
+                        /* closing quote must be followed by a space or
+                         * nothing at all. */
+                        if (*(p+1) && !isspace(*(p+1))) goto err;
+                        done=1;
+                    } else if (!*p) {
+                        /* unterminated quotes */
+                        goto err;
+                    } else {
+                        current = sdscatlen(current,p,1);
+                    }
+                } else if (insq) {
+                    if (*p == '\\' && *(p+1) == '\'') {
+                        p++;
+                        current = sdscatlen(current,"'",1);
+                    } else if (*p == '\'') {
+                        /* closing quote must be followed by a space or
+                         * nothing at all. */
+                        if (*(p+1) && !isspace(*(p+1))) goto err;
+                        done=1;
+                    } else if (!*p) {
+                        /* unterminated quotes */
+                        goto err;
+                    } else {
+                        current = sdscatlen(current,p,1);
+                    }
+                } else {
+                    switch(*p) {
+                    case ' ':
+                    case '\n':
+                    case '\r':
+                    case '\t':
+                    case '\0':
+                        done=1;
+                        break;
+                    case '"':
+                        inq=1;
+                        break;
+                    case '\'':
+                        insq=1;
+                        break;
+                    default:
+                        current = sdscatlen(current,p,1);
+                        break;
+                    }
+                }
+                if (*p) p++;
+            }
+            /* add the token to the vector */
+            vector = s_realloc(vector,((*argc)+1)*sizeof(char*));
+            vector[*argc] = current;
+            (*argc)++;
+            current = NULL;
+        } else {
+            /* Even on empty input string return something not NULL. */
+            if (vector == NULL) vector = s_malloc(sizeof(void*));
+            return vector;
+        }
+    }
+
+err:
+    while((*argc)--)
+        sdsfree(vector[*argc]);
+    s_free(vector);
+    if (current) sdsfree(current);
+    *argc = 0;
+    return NULL;
+}
+
+/* Modify the string substituting all the occurrences of the set of
+ * characters specified in the 'from' string to the corresponding character
+ * in the 'to' array.
+ *
+ * For instance: sdsmapchars(mystring, "ho", "01", 2)
+ * will have the effect of turning the string "hello" into "0ell1".
+ *
+ * The function returns the sds string pointer, that is always the same
+ * as the input pointer since no resize is needed. */
+sds sdsmapchars(sds s, const char *from, const char *to, size_t setlen) {
+    size_t j, i, l = sdslen(s);
+
+    for (j = 0; j < l; j++) {
+        for (i = 0; i < setlen; i++) {
+            if (s[j] == from[i]) {
+                s[j] = to[i];
+                break;
+            }
+        }
+    }
+    return s;
+}
+
+/* Join an array of C strings using the specified separator (also a C string).
+ * Returns the result as an sds string. */
+sds sdsjoin(char **argv, int argc, char *sep) {
+    sds join = sdsempty();
+    int j;
+
+    for (j = 0; j < argc; j++) {
+        join = sdscat(join, argv[j]);
+        if (j != argc-1) join = sdscat(join,sep);
+    }
+    return join;
+}
+
+/* Like sdsjoin, but joins an array of SDS strings. */
+sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen) {
+    sds join = sdsempty();
+    int j;
+
+    for (j = 0; j < argc; j++) {
+        join = sdscatsds(join, argv[j]);
+        if (j != argc-1) join = sdscatlen(join,sep,seplen);
+    }
+    return join;
+}
+
+/* Wrappers to the allocators used by SDS. Note that SDS will actually
+ * just use the macros defined into sdsalloc.h in order to avoid to pay
+ * the overhead of function calls. Here we define these wrappers only for
+ * the programs SDS is linked to, if they want to touch the SDS internals
+ * even if they use a different allocator. */
+void *sds_malloc(size_t size) { return s_malloc(size); }
+void *sds_realloc(void *ptr, size_t size) { return s_realloc(ptr,size); }
+void sds_free(void *ptr) { s_free(ptr); }
+
+#if defined(SDS_TEST_MAIN)
+#include <stdio.h>
+#include "testhelp.h"
+#include "limits.h"
+
+#define UNUSED(x) (void)(x)
+int sdsTest(void) {
+    {
+        sds x = sdsnew("foo"), y;
+
+        test_cond("Create a string and obtain the length",
+            sdslen(x) == 3 && memcmp(x,"foo\0",4) == 0)
+
+        sdsfree(x);
+        x = sdsnewlen("foo",2);
+        test_cond("Create a string with specified length",
+            sdslen(x) == 2 && memcmp(x,"fo\0",3) == 0)
+
+        x = sdscat(x,"bar");
+        test_cond("Strings concatenation",
+            sdslen(x) == 5 && memcmp(x,"fobar\0",6) == 0);
+
+        x = sdscpy(x,"a");
+        test_cond("sdscpy() against an originally longer string",
+            sdslen(x) == 1 && memcmp(x,"a\0",2) == 0)
+
+        x = sdscpy(x,"xyzxxxxxxxxxxyyyyyyyyyykkkkkkkkkk");
+        test_cond("sdscpy() against an originally shorter string",
+            sdslen(x) == 33 &&
+            memcmp(x,"xyzxxxxxxxxxxyyyyyyyyyykkkkkkkkkk\0",33) == 0)
+
+        sdsfree(x);
+        x = sdscatprintf(sdsempty(),"%d",123);
+        test_cond("sdscatprintf() seems working in the base case",
+            sdslen(x) == 3 && memcmp(x,"123\0",4) == 0)
+
+        sdsfree(x);
+        x = sdsnew("--");
+        x = sdscatfmt(x, "Hello %s World %I,%I--", "Hi!", LLONG_MIN,LLONG_MAX);
+        test_cond("sdscatfmt() seems working in the base case",
+            sdslen(x) == 60 &&
+            memcmp(x,"--Hello Hi! World -9223372036854775808,"
+                     "9223372036854775807--",60) == 0)
+        printf("[%s]\n",x);
+
+        sdsfree(x);
+        x = sdsnew("--");
+        x = sdscatfmt(x, "%u,%U--", UINT_MAX, ULLONG_MAX);
+        test_cond("sdscatfmt() seems working with unsigned numbers",
+            sdslen(x) == 35 &&
+            memcmp(x,"--4294967295,18446744073709551615--",35) == 0)
+
+        sdsfree(x);
+        x = sdsnew(" x ");
+        sdstrim(x," x");
+        test_cond("sdstrim() works when all chars match",
+            sdslen(x) == 0)
+
+        sdsfree(x);
+        x = sdsnew(" x ");
+        sdstrim(x," ");
+        test_cond("sdstrim() works when a single char remains",
+            sdslen(x) == 1 && x[0] == 'x')
+
+        sdsfree(x);
+        x = sdsnew("xxciaoyyy");
+        sdstrim(x,"xy");
+        test_cond("sdstrim() correctly trims characters",
+            sdslen(x) == 4 && memcmp(x,"ciao\0",5) == 0)
+
+        y = sdsdup(x);
+        sdsrange(y,1,1);
+        test_cond("sdsrange(...,1,1)",
+            sdslen(y) == 1 && memcmp(y,"i\0",2) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,1,-1);
+        test_cond("sdsrange(...,1,-1)",
+            sdslen(y) == 3 && memcmp(y,"iao\0",4) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,-2,-1);
+        test_cond("sdsrange(...,-2,-1)",
+            sdslen(y) == 2 && memcmp(y,"ao\0",3) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,2,1);
+        test_cond("sdsrange(...,2,1)",
+            sdslen(y) == 0 && memcmp(y,"\0",1) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,1,100);
+        test_cond("sdsrange(...,1,100)",
+            sdslen(y) == 3 && memcmp(y,"iao\0",4) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,100,100);
+        test_cond("sdsrange(...,100,100)",
+            sdslen(y) == 0 && memcmp(y,"\0",1) == 0)
+
+        sdsfree(y);
+        sdsfree(x);
+        x = sdsnew("foo");
+        y = sdsnew("foa");
+        test_cond("sdscmp(foo,foa)", sdscmp(x,y) > 0)
+
+        sdsfree(y);
+        sdsfree(x);
+        x = sdsnew("bar");
+        y = sdsnew("bar");
+        test_cond("sdscmp(bar,bar)", sdscmp(x,y) == 0)
+
+        sdsfree(y);
+        sdsfree(x);
+        x = sdsnew("aar");
+        y = sdsnew("bar");
+        test_cond("sdscmp(bar,bar)", sdscmp(x,y) < 0)
+
+        sdsfree(y);
+        sdsfree(x);
+        x = sdsnewlen("\a\n\0foo\r",7);
+        y = sdscatrepr(sdsempty(),x,sdslen(x));
+        test_cond("sdscatrepr(...data...)",
+            memcmp(y,"\"\\a\\n\\x00foo\\r\"",15) == 0)
+
+        {
+            unsigned int oldfree;
+            char *p;
+            int step = 10, j, i;
+
+            sdsfree(x);
+            sdsfree(y);
+            x = sdsnew("0");
+            test_cond("sdsnew() free/len buffers", sdslen(x) == 1 && sdsavail(x) == 0);
+
+            /* Run the test a few times in order to hit the first two
+             * SDS header types. */
+            for (i = 0; i < 10; i++) {
+                int oldlen = sdslen(x);
+                x = sdsMakeRoomFor(x,step);
+                int type = x[-1]&SDS_TYPE_MASK;
+
+                test_cond("sdsMakeRoomFor() len", sdslen(x) == oldlen);
+                if (type != SDS_TYPE_5) {
+                    test_cond("sdsMakeRoomFor() free", sdsavail(x) >= step);
+                    oldfree = sdsavail(x);
+                }
+                p = x+oldlen;
+                for (j = 0; j < step; j++) {
+                    p[j] = 'A'+j;
+                }
+                sdsIncrLen(x,step);
+            }
+            test_cond("sdsMakeRoomFor() content",
+                memcmp("0ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ",x,101) == 0);
+            test_cond("sdsMakeRoomFor() final length",sdslen(x)==101);
+
+            sdsfree(x);
+        }
+    }
+    test_report()
+    return 0;
+}
+#endif
+
+#ifdef SDS_TEST_MAIN
+int main(void) {
+    return sdsTest();
+}
+#endif
+

--- a/lib/sds/sds.h
+++ b/lib/sds/sds.h
@@ -1,0 +1,275 @@
+/* SDSLib 2.0 -- A C dynamic strings library
+ *
+ * Copyright (c) 2006-2015, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2015, Oran Agra
+ * Copyright (c) 2015, Redis Labs, Inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __SDS_H
+#define __SDS_H
+
+#define SDS_MAX_PREALLOC (1024*1024)
+extern const char *SDS_NOINIT;
+
+#include <sys/types.h>
+#include <stdarg.h>
+#include <stdint.h>
+
+typedef char *sds;
+
+/* Note: sdshdr5 is never used, we just access the flags byte directly.
+ * However is here to document the layout of type 5 SDS strings. */
+struct __attribute__ ((__packed__)) sdshdr5 {
+    unsigned char flags; /* 3 lsb of type, and 5 msb of string length */
+    char buf[];
+};
+struct __attribute__ ((__packed__)) sdshdr8 {
+    uint8_t len; /* used */
+    uint8_t alloc; /* excluding the header and null terminator */
+    unsigned char flags; /* 3 lsb of type, 5 unused bits */
+    char buf[];
+};
+struct __attribute__ ((__packed__)) sdshdr16 {
+    uint16_t len; /* used */
+    uint16_t alloc; /* excluding the header and null terminator */
+    unsigned char flags; /* 3 lsb of type, 5 unused bits */
+    char buf[];
+};
+struct __attribute__ ((__packed__)) sdshdr32 {
+    uint32_t len; /* used */
+    uint32_t alloc; /* excluding the header and null terminator */
+    unsigned char flags; /* 3 lsb of type, 5 unused bits */
+    char buf[];
+};
+struct __attribute__ ((__packed__)) sdshdr64 {
+    uint64_t len; /* used */
+    uint64_t alloc; /* excluding the header and null terminator */
+    unsigned char flags; /* 3 lsb of type, 5 unused bits */
+    char buf[];
+};
+
+#define SDS_TYPE_5  0
+#define SDS_TYPE_8  1
+#define SDS_TYPE_16 2
+#define SDS_TYPE_32 3
+#define SDS_TYPE_64 4
+#define SDS_TYPE_MASK 7
+#define SDS_TYPE_BITS 3
+#define SDS_HDR_VAR(T,s) struct sdshdr##T *sh = (void*)((s)-(sizeof(struct sdshdr##T)));
+#define SDS_HDR(T,s) ((struct sdshdr##T *)((s)-(sizeof(struct sdshdr##T))))
+#define SDS_TYPE_5_LEN(f) ((f)>>SDS_TYPE_BITS)
+
+static inline size_t sdslen(const sds s) {
+    unsigned char flags = s[-1];
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            return SDS_TYPE_5_LEN(flags);
+        case SDS_TYPE_8:
+            return SDS_HDR(8,s)->len;
+        case SDS_TYPE_16:
+            return SDS_HDR(16,s)->len;
+        case SDS_TYPE_32:
+            return SDS_HDR(32,s)->len;
+        case SDS_TYPE_64:
+            return SDS_HDR(64,s)->len;
+    }
+    return 0;
+}
+
+static inline size_t sdsavail(const sds s) {
+    unsigned char flags = s[-1];
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5: {
+            return 0;
+        }
+        case SDS_TYPE_8: {
+            SDS_HDR_VAR(8,s);
+            return sh->alloc - sh->len;
+        }
+        case SDS_TYPE_16: {
+            SDS_HDR_VAR(16,s);
+            return sh->alloc - sh->len;
+        }
+        case SDS_TYPE_32: {
+            SDS_HDR_VAR(32,s);
+            return sh->alloc - sh->len;
+        }
+        case SDS_TYPE_64: {
+            SDS_HDR_VAR(64,s);
+            return sh->alloc - sh->len;
+        }
+    }
+    return 0;
+}
+
+static inline void sdssetlen(sds s, size_t newlen) {
+    unsigned char flags = s[-1];
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            {
+                unsigned char *fp = ((unsigned char*)s)-1;
+                *fp = SDS_TYPE_5 | (newlen << SDS_TYPE_BITS);
+            }
+            break;
+        case SDS_TYPE_8:
+            SDS_HDR(8,s)->len = newlen;
+            break;
+        case SDS_TYPE_16:
+            SDS_HDR(16,s)->len = newlen;
+            break;
+        case SDS_TYPE_32:
+            SDS_HDR(32,s)->len = newlen;
+            break;
+        case SDS_TYPE_64:
+            SDS_HDR(64,s)->len = newlen;
+            break;
+    }
+}
+
+static inline void sdsinclen(sds s, size_t inc) {
+    unsigned char flags = s[-1];
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            {
+                unsigned char *fp = ((unsigned char*)s)-1;
+                unsigned char newlen = SDS_TYPE_5_LEN(flags)+inc;
+                *fp = SDS_TYPE_5 | (newlen << SDS_TYPE_BITS);
+            }
+            break;
+        case SDS_TYPE_8:
+            SDS_HDR(8,s)->len += inc;
+            break;
+        case SDS_TYPE_16:
+            SDS_HDR(16,s)->len += inc;
+            break;
+        case SDS_TYPE_32:
+            SDS_HDR(32,s)->len += inc;
+            break;
+        case SDS_TYPE_64:
+            SDS_HDR(64,s)->len += inc;
+            break;
+    }
+}
+
+/* sdsalloc() = sdsavail() + sdslen() */
+static inline size_t sdsalloc(const sds s) {
+    unsigned char flags = s[-1];
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            return SDS_TYPE_5_LEN(flags);
+        case SDS_TYPE_8:
+            return SDS_HDR(8,s)->alloc;
+        case SDS_TYPE_16:
+            return SDS_HDR(16,s)->alloc;
+        case SDS_TYPE_32:
+            return SDS_HDR(32,s)->alloc;
+        case SDS_TYPE_64:
+            return SDS_HDR(64,s)->alloc;
+    }
+    return 0;
+}
+
+static inline void sdssetalloc(sds s, size_t newlen) {
+    unsigned char flags = s[-1];
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            /* Nothing to do, this type has no total allocation info. */
+            break;
+        case SDS_TYPE_8:
+            SDS_HDR(8,s)->alloc = newlen;
+            break;
+        case SDS_TYPE_16:
+            SDS_HDR(16,s)->alloc = newlen;
+            break;
+        case SDS_TYPE_32:
+            SDS_HDR(32,s)->alloc = newlen;
+            break;
+        case SDS_TYPE_64:
+            SDS_HDR(64,s)->alloc = newlen;
+            break;
+    }
+}
+
+sds sdsnewlen(const void *init, size_t initlen);
+sds sdsnew(const char *init);
+sds sdsempty(void);
+sds sdsdup(const sds s);
+void sdsfree(sds s);
+sds sdsgrowzero(sds s, size_t len);
+sds sdscatlen(sds s, const void *t, size_t len);
+sds sdscat(sds s, const char *t);
+sds sdscatsds(sds s, const sds t);
+sds sdscpylen(sds s, const char *t, size_t len);
+sds sdscpy(sds s, const char *t);
+
+sds sdscatvprintf(sds s, const char *fmt, va_list ap);
+#ifdef __GNUC__
+sds sdscatprintf(sds s, const char *fmt, ...)
+    __attribute__((format(printf, 2, 3)));
+#else
+sds sdscatprintf(sds s, const char *fmt, ...);
+#endif
+
+sds sdscatfmt(sds s, char const *fmt, ...);
+sds sdstrim(sds s, const char *cset);
+void sdsrange(sds s, ssize_t start, ssize_t end);
+void sdsupdatelen(sds s);
+void sdsclear(sds s);
+int sdscmp(const sds s1, const sds s2);
+sds *sdssplitlen(const char *s, ssize_t len, const char *sep, int seplen, int *count);
+void sdsfreesplitres(sds *tokens, int count);
+void sdstolower(sds s);
+void sdstoupper(sds s);
+sds sdsfromlonglong(long long value);
+sds sdscatrepr(sds s, const char *p, size_t len);
+sds *sdssplitargs(const char *line, int *argc);
+sds sdsmapchars(sds s, const char *from, const char *to, size_t setlen);
+sds sdsjoin(char **argv, int argc, char *sep);
+sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen);
+
+/* Low level functions exposed to the user API */
+sds sdsMakeRoomFor(sds s, size_t addlen);
+void sdsIncrLen(sds s, ssize_t incr);
+sds sdsRemoveFreeSpace(sds s);
+size_t sdsAllocSize(sds s);
+void *sdsAllocPtr(sds s);
+
+/* Export the allocator used by SDS to the program using SDS.
+ * Sometimes the program SDS is linked to, may use a different set of
+ * allocators, but may want to allocate or free things that SDS will
+ * respectively free or allocate. */
+void *sds_malloc(size_t size);
+void *sds_realloc(void *ptr, size_t size);
+void sds_free(void *ptr);
+
+#ifdef REDIS_TEST
+int sdsTest(int argc, char *argv[]);
+#endif
+
+#endif
+

--- a/lib/sds/sdsalloc.h
+++ b/lib/sds/sdsalloc.h
@@ -1,0 +1,43 @@
+/* SDSLib 2.0 -- A C dynamic strings library
+ *
+ * Copyright (c) 2006-2015, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2015, Oran Agra
+ * Copyright (c) 2015, Redis Labs, Inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* SDS allocator selection.
+ *
+ * This file is used in order to change the SDS allocator at compile time.
+ * Just define the following defines to what you want to use. Also add
+ * the include of your alternate allocator if needed (not needed in order
+ * to use the default libc allocator). */
+
+#define s_malloc malloc
+#define s_realloc realloc
+#define s_free free
+

--- a/test/runner.c
+++ b/test/runner.c
@@ -7,6 +7,7 @@ int main(int argc, char **argv)
     (void) argv;
 
     inquery_test_suite_heap();
+    inquery_test_suite_string();
     inquery_test_suite_object();
 
     return 0;

--- a/test/string.c
+++ b/test/string.c
@@ -14,6 +14,7 @@ static void test_new_empty_1(void)
 }
 
 
+
 static void test_new_1(void)
 {
     printf("inquery_string_new() can create an ASCII string...");
@@ -395,6 +396,7 @@ static void test_find_9(void)
 
     printf("...OK\n");
 }
+
 
 extern void inquery_test_suite_string(void)
 {

--- a/test/string.c
+++ b/test/string.c
@@ -187,7 +187,7 @@ static void test_cmp_4(void)
     inquery_string_smart *rhs = inquery_string_new("Goodbye, moon?");
     inquery_require (inquery_string_cmp(lhs, rhs));
 
-    printf("OK\n");;
+    printf("OK\n");
 }
 
 
@@ -199,7 +199,7 @@ static void test_cmp_5(void)
     inquery_string_smart *rhs = inquery_string_new("До свидания, луна?");
     inquery_require (inquery_string_cmp(lhs, rhs));
 
-    printf("OK\n");;
+    printf("OK\n");
 }
 
 
@@ -225,7 +225,7 @@ static void test_cmp_7(void)
     inquery_string_smart *rhs = inquery_string_new("Привет, мир!");
     inquery_require (inquery_string_cmp(lhs, rhs) < 0);
 
-    printf("OK\n");;
+    printf("OK\n");
 }
 
 
@@ -238,7 +238,7 @@ static void test_cmp_8(void)
     inquery_string_smart *rhs = inquery_string_new("Hello, world!");
     inquery_require (inquery_string_cmp(rhs, lhs) > 0);
 
-    printf("OK\n");;
+    printf("OK\n");
 }
 
 
@@ -251,7 +251,7 @@ static void test_cmp_9(void)
     inquery_string_smart *rhs = inquery_string_new("Привет, мир!");
     inquery_require (inquery_string_cmp(rhs, lhs) > 0);
 
-    printf("OK\n");;
+    printf("OK\n");
 }
 
 
@@ -263,7 +263,7 @@ static void test_add_1(void)
     inquery_string_add(&test, "");
     inquery_require (!*test);
 
-    printf("OK\n");;
+    printf("OK\n");
 }
 
 
@@ -277,7 +277,7 @@ static void test_add_2(void)
     inquery_string_add(&test, "!");
     inquery_require (!strcmp(test, "Hello, world!"));
 
-    printf("OK\n");;
+    printf("OK\n");
 }
 
 
@@ -292,7 +292,7 @@ static void test_add_3(void)
     inquery_string_add(&test, "?");
     inquery_require (!strcmp(test, expect));
 
-    printf("OK\n");;
+    printf("OK\n");
 }
 
 
@@ -529,6 +529,137 @@ static void inquery_string_replace_first_test_10(void)
 }
 
 
+static void inquery_string_replace_test_1(void)
+{
+    printf("inquery_string_replace() replaces an ASCII character with a null"
+            " character");
+    
+    inquery_string_smart *test = inquery_string_new("Hello, world!");
+    inquery_string_replace(&test, "!", "");
+    inquery_require (!strcmp(test, "Hello, world"));
+    
+    printf("...OK\n");
+}
+
+
+static void inquery_string_replace_test_2(void)
+{
+    printf("inquery_string_replace() replaces a Unicode character with a null"
+            " character");
+    
+    inquery_string_smart *test = inquery_string_new("Привет, мир!");
+    inquery_string_replace(&test, "т", "");
+    inquery_require (!strcmp(test, "Приве, мир!"));
+    
+    printf("...OK\n");
+}
+
+
+static void inquery_string_replace_test_3(void)
+{
+    printf("inquery_string_replace() replaces all the instances in an ASCII"
+            " string");
+
+    inquery_string_smart *test = inquery_string_new("Hello, world!");
+    inquery_string_replace(&test, "l", "y");
+    inquery_require (!strcmp(test, "Heyyo, woryd!"));
+    
+    printf("...OK\n");
+}
+
+
+static void inquery_string_replace_test_4(void)
+{
+    printf("inquery_string_replace() replaces all the instances in a Unicode"
+            " string");
+    
+    inquery_string_smart *test = inquery_string_new("Привет, мир!");
+    inquery_string_replace(&test, "р", "r");
+    inquery_require (!strcmp(test, "Пrивет, миr!"));
+    
+    printf("...OK\n");
+}
+
+
+static void inquery_string_replace_test_5(void)
+{
+    printf("inquery_string_replace() replaces an ASCII substring");
+    
+    inquery_string_smart *test = inquery_string_new("Hello, world!");
+    inquery_string_replace(&test, "world", "moon");
+    inquery_require (!strcmp(test, "Hello, moon!"));
+    
+    printf("...OK\n");
+}
+
+
+static void inquery_string_replace_test_6(void)
+{
+    printf("inquery_string_replace() replaces a Unicode substring");
+    
+    inquery_string_smart *test = inquery_string_new("Привет, мир!");
+    inquery_string_replace(&test, "Привет", "До свидания");
+    inquery_require (!strcmp(test, "До свидания, мир!"));
+
+    printf("...OK\n");
+}
+
+
+static void inquery_string_replace_test_7(void)
+{
+    printf("inquery_string_replace() replaces an entire ASCII string");
+    
+    const inquery_string *expect = "Goodbye, moon?";
+    inquery_string_smart *test = inquery_string_new("Hello, world!");
+    inquery_string_replace(&test, "Hello, world!", expect);
+    inquery_require (!strcmp(test, expect));
+    
+    printf("...OK\n");
+}
+
+
+static void inquery_string_replace_test_8(void)
+{
+    printf("inquery_string_replace() replaces an entire Unicode string");
+    
+    const inquery_string *expect = "До свидания, луна?";
+    inquery_string_smart *test = inquery_string_new("Привет, мир!");
+    inquery_string_replace(&test, "Привет, мир!", expect);
+    inquery_require (!strcmp(test, expect));
+
+    printf("...OK\n");
+}
+
+
+static void inquery_string_replace_test_9(void)
+{
+    printf("inquery_string_replace() has no effect if @ctx, @what, and @with"
+            " are all the same");
+
+    inquery_string_smart *test = inquery_string_new("Hello, world!");
+    inquery_string_smart *what = inquery_string_new("Hello, world!");
+    inquery_string_smart *with = inquery_string_new("Hello, world!");
+    inquery_string_replace(&test, what, with);
+    inquery_require (!strcmp(test, what));
+    
+    printf("...OK\n");
+}
+
+
+static void inquery_string_replace_test_10(void)
+{
+    printf("inquery_string_replace() can replace all instance of the same"
+            " sequence of characters");
+    
+    inquery_string_smart *test = inquery_string_new("Hello, world!");
+    inquery_string_smart *expect = inquery_string_new("Hellllo, worlld!");
+    inquery_string_replace(&test, "l", "ll");
+    inquery_require (!inquery_string_cmp(test, expect));
+    
+    printf("...OK\n");
+}
+
+
 extern void inquery_test_suite_string(void)
 {
     printf("===============================================================\n");
@@ -584,6 +715,17 @@ extern void inquery_test_suite_string(void)
     inquery_string_replace_first_test_8();
     inquery_string_replace_first_test_9();
     inquery_string_replace_first_test_10();
+
+    inquery_string_replace_test_1();
+    inquery_string_replace_test_2();
+    inquery_string_replace_test_3();
+    inquery_string_replace_test_4();
+    inquery_string_replace_test_5();
+    inquery_string_replace_test_6();
+    inquery_string_replace_test_7();
+    inquery_string_replace_test_8();
+    inquery_string_replace_test_9();
+    inquery_string_replace_test_10();
 
     printf("\n");
 }

--- a/test/string.c
+++ b/test/string.c
@@ -3,7 +3,10 @@
 #include "suite.h"
 
 
-static void test_new_empty_1(void)
+/*
+ * new_empty_1() - test case #1 for inquery_string_new_empty()
+ */
+static void new_empty_1(void)
 {
     printf("inquery_string_new_empty() can create an empty string...");
 
@@ -14,8 +17,10 @@ static void test_new_empty_1(void)
 }
 
 
-
-static void test_new_1(void)
+/*
+ * new_1() - test case #1 for inquery_string_new()
+ */
+static void new_1(void)
 {
     printf("inquery_string_new() can create an ASCII string...");
 
@@ -27,7 +32,10 @@ static void test_new_1(void)
 }
 
 
-static void test_new_2(void)
+/*
+ * new_2() - test case #2 for inquery_string_new()
+ */
+static void new_2(void)
 {
     printf("inquery_string_new() can create a Unicode string...");
 
@@ -38,7 +46,11 @@ static void test_new_2(void)
     printf("OK\n");
 }
 
-static void test_copy_1(void)
+
+/*
+ * copy_1() - test case #1 for inquery_string_copy()
+ */
+static void copy_1(void)
 {
     printf("inquery_string_copy() can copy an empty string...");
 
@@ -50,7 +62,10 @@ static void test_copy_1(void)
 }
 
 
-static void test_copy_2(void)
+/*
+ * copy_2() - test case #2 for inquery_string_copy()
+ */
+static void copy_2(void)
 {
     printf("inquery_string_copy() can copy an ASCII string...");
 
@@ -63,7 +78,10 @@ static void test_copy_2(void)
 }
 
 
-static void test_copy_3(void)
+/*
+ * copy_3() - test case #3 for inquery_string_copy()
+ */
+static void copy_3(void)
 {
     printf("inquery_string_copy() can copy a Unicode string...");
 
@@ -76,7 +94,10 @@ static void test_copy_3(void)
 }
 
 
-static void test_len_1(void)
+/*
+ * len_1() - test case #1 for inquery_string_len()
+ */
+static void len_1(void)
 {
     printf("inquery_string_len() reports 0 for a null string...");
 
@@ -87,7 +108,10 @@ static void test_len_1(void)
 }
 
 
-static void test_len_2(void)
+/*
+ * len_2() - test case #2 for inquery_string_len()
+ */
+static void len_2(void)
 {
     printf("inquery_string_len() reports the length of an ASCII string...");
 
@@ -98,7 +122,10 @@ static void test_len_2(void)
 }
 
 
-static void test_len_3(void)
+/*
+ * len_3() - test case #3 for inquery_string_len()
+ */
+static void len_3(void)
 {
     printf("inquery_string_len() reports the length of a Unicode string...");
 
@@ -109,7 +136,10 @@ static void test_len_3(void)
 }
 
 
-static void test_sz_1(void)
+/*
+ * sz_1() - test case #1 for inquery_string_sz()
+ */
+static void sz_1(void)
 {
     printf("inquery_string_sz() reports 1 for a null string...");
 
@@ -120,7 +150,10 @@ static void test_sz_1(void)
 }
 
 
-static void test_sz_2(void)
+/*
+ * sz_2() - test case #2 for inquery_string_sz()
+ */
+static void sz_2(void)
 {
     printf("inquery_string_sz() reports the size of an ASCII string...");
 
@@ -132,7 +165,10 @@ static void test_sz_2(void)
 }
 
 
-static void test_sz_3(void)
+/*
+ * sz_3() - test case #3 for inquery_string_sz()
+ */
+static void sz_3(void)
 {
     printf("inquery_string_sz() reports the size of a Unicode string...");
 
@@ -144,7 +180,10 @@ static void test_sz_3(void)
 }
 
 
-static void test_cmp_1(void)
+/*
+ * cmp_1() - test case #1 for inquery_string_cmp()
+ */
+static void cmp_1(void)
 {
     printf("inquery_string_cmp() detects two equal null strings...");
 
@@ -156,7 +195,10 @@ static void test_cmp_1(void)
 }
 
 
-static void test_cmp_2(void)
+/*
+ * cmp_2() - test case #2 for inquery_string_cmp()
+ */
+static void cmp_2(void)
 {
     printf("inquery_string_cmp() detects two equal ASCII strings...");
 
@@ -168,7 +210,10 @@ static void test_cmp_2(void)
 }
 
 
-static void test_cmp_3(void)
+/*
+ * cmp_3() - test case #3 for inquery_string_cmp()
+ */
+static void cmp_3(void)
 {
     printf("inquery_string_cmp() detects two equal Unicode strings...");
 
@@ -179,7 +224,11 @@ static void test_cmp_3(void)
     printf("OK\n");
 }
 
-static void test_cmp_4(void)
+
+/*
+ * cmp_4() - test case #4 for inquery_string_cmp()
+ */
+static void cmp_4(void)
 {
     printf("inquery_string_cmp() detects two unequal ASCII strings...");
 
@@ -191,7 +240,10 @@ static void test_cmp_4(void)
 }
 
 
-static void test_cmp_5(void)
+/*
+ * cmp_5() - test case #5 for inquery_string_cmp()
+ */
+static void cmp_5(void)
 {
     printf("inquery_string_cmp() detects two unequal Unicode strings...");
 
@@ -203,7 +255,10 @@ static void test_cmp_5(void)
 }
 
 
-static void test_cmp_6(void)
+/*
+ * cmp_6() - test case #6 for inquery_string_cmp()
+ */
+static void cmp_6(void)
 {
     printf("inquery_string_cmp() detects a lexicographically smaller ASCII"
             " string...");
@@ -216,7 +271,10 @@ static void test_cmp_6(void)
 }
 
 
-static void test_cmp_7(void)
+/*
+ * cmp_7() - test case #7 for inquery_string_cmp()
+ */
+static void cmp_7(void)
 {
     printf("inquery_string_cmp() detects a lexicographically smaller Unicode"
             " string...");
@@ -229,7 +287,10 @@ static void test_cmp_7(void)
 }
 
 
-static void test_cmp_8(void)
+/*
+ * cmp_8() - test case #8 for inquery_string_cmp()
+ */
+static void cmp_8(void)
 {
     printf("inquery_string_cmp() detects a lexicographically greater ASCII"
             "string...");
@@ -242,7 +303,10 @@ static void test_cmp_8(void)
 }
 
 
-static void test_cmp_9(void)
+/*
+ * cmp_9() - test case #9 for inquery_string_cmp()
+ */
+static void cmp_9(void)
 {
     printf("inquery_string_cmp() detects a lexicographically greater Unicode"
             " string...");
@@ -255,7 +319,10 @@ static void test_cmp_9(void)
 }
 
 
-static void test_add_1(void)
+/*
+ * add_1() - test case #1 for inquery_string_add()
+ */
+static void add_1(void)
 {
     printf("inquery_string_add() adds two null strings...");
 
@@ -267,7 +334,10 @@ static void test_add_1(void)
 }
 
 
-static void test_add_2(void)
+/*
+ * add_2() - test case #2 for inquery_string_add()
+ */
+static void add_2(void)
 {
     printf("inquery_string_add() adds two ASCII strings...");
 
@@ -281,7 +351,10 @@ static void test_add_2(void)
 }
 
 
-static void test_add_3(void)
+/*
+ * add_3() - test case #3 for inquery_string_add()
+ */
+static void add_3(void)
 {
     printf("inquery_string_add() adds two Unicode strings...");
 
@@ -296,7 +369,10 @@ static void test_add_3(void)
 }
 
 
-static void test_find_1(void)
+/*
+ * find_1() - test case #1 for inquery_string_find()
+ */
+static void find_1(void)
 {
     printf("inquery_string_find() can find a null string");
 
@@ -307,7 +383,10 @@ static void test_find_1(void)
 }
 
 
-static void test_find_2(void)
+/*
+ * find_2() - test case #2 for inquery_string_find()
+ */
+static void find_2(void)
 {
     printf("inquery_string_find() can find an ASCII string with 1 character");
 
@@ -318,7 +397,10 @@ static void test_find_2(void)
 }
 
 
-static void test_find_3(void)
+/*
+ * find_3() - test case #3 for inquery_string_find()
+ */
+static void find_3(void)
 {
     printf("inquery_string_find() can find a Unicode string with 1 character");
 
@@ -329,7 +411,10 @@ static void test_find_3(void)
 }
 
 
-static void test_find_4(void)
+/*
+ * find_4() - test case #4 for inquery_string_find()
+ */
+static void find_4(void)
 {
     printf("inquery_string_find() can find an ASCII string");
 
@@ -340,7 +425,10 @@ static void test_find_4(void)
 }
 
 
-static void test_find_5(void)
+/*
+ * find_5() - test case #5 for inquery_string_find()
+ */
+static void find_5(void)
 {
     printf("inquery_string_find() can find a Unicode string");
 
@@ -351,8 +439,10 @@ static void test_find_5(void)
 }
 
 
-
-static void test_find_6(void)
+/*
+ * find_6() - test case #5 for inquery_string_find()
+ */
+static void find_6(void)
 {
     printf("inquery_string_find() can detect the absence of an ASCII string"
             " with 1 character");
@@ -364,7 +454,10 @@ static void test_find_6(void)
 }
 
 
-static void test_find_7(void)
+/*
+ * find_7() - test case #5 for inquery_string_find()
+ */
+static void find_7(void)
 {
     printf("inquery_string_find() can detect the absence of a Unicode string"
             " with 1 character");
@@ -376,7 +469,10 @@ static void test_find_7(void)
 }
 
 
-static void test_find_8(void)
+/*
+ * find_8() - test case #8 for inquery_string_find()
+ */
+static void find_8(void)
 {
     printf("inquery_string_find() can detect the absence of an ASCII string");
 
@@ -387,7 +483,10 @@ static void test_find_8(void)
 }
 
 
-static void test_find_9(void)
+/*
+ * find_9() - test case #9 for inquery_string_find()
+ */
+static void find_9(void)
 {
     printf("inquery_string_find() can detect the absence of a Unicode string");
 
@@ -398,10 +497,13 @@ static void test_find_9(void)
 }
 
 
-static void inquery_string_replace_first_test_1(void)
+/*
+ * replace_first_1() - test case #1 for inquery_string_replace_first()
+ */
+static void replace_first_1(void)
 {
-    printf("inquery_string_replace_first() replaces an ASCII character with a null"
-            " character");
+    printf("inquery_string_replace_first() replaces an ASCII character with a"
+            " null character");
 
     inquery_string_smart *test = inquery_string_new("Hello, world!");
     inquery_string_replace_first(&test, "!", "");
@@ -411,7 +513,10 @@ static void inquery_string_replace_first_test_1(void)
 }
 
 
-static void inquery_string_replace_first_test_2(void)
+/*
+ * replace_first_2() - test case #2 for inquery_string_replace_first()
+ */
+static void replace_first_2(void)
 {
     printf("inquery_string_replace_first() replaces a Unicode character with a"
             " null character");
@@ -424,7 +529,10 @@ static void inquery_string_replace_first_test_2(void)
 }
 
 
-static void inquery_string_replace_first_test_3(void)
+/*
+ * replace_first_3() - test case #3 for inquery_string_replace_first()
+ */
+static void replace_first_3(void)
 {
     printf("inquery_string_replace_first() replaces only the first instance in an"
             " ASCII string");
@@ -437,7 +545,10 @@ static void inquery_string_replace_first_test_3(void)
 }
 
 
-static void inquery_string_replace_first_test_4(void)
+/*
+ * replace_first_4() - test case #4 for inquery_string_replace_first()
+ */
+static void replace_first_4(void)
 {
     printf("inquery_string_replace_first() replaces only the first instance in a"
             " Unicode string");
@@ -450,7 +561,10 @@ static void inquery_string_replace_first_test_4(void)
 }
 
 
-static void inquery_string_replace_first_test_5(void)
+/*
+ * replace_first_5() - test case #5 for inquery_string_replace_first()
+ */
+static void replace_first_5(void)
 {
     printf("inquery_string_replace_first() replaces an ASCII substring");
 
@@ -462,7 +576,10 @@ static void inquery_string_replace_first_test_5(void)
 }
 
 
-static void inquery_string_replace_first_test_6(void)
+/*
+ * replace_first_6() - test case #6 for inquery_string_replace_first()
+ */
+static void replace_first_6(void)
 {
     printf("inquery_string_replace_first() replaces a Unicode substring");
 
@@ -474,7 +591,10 @@ static void inquery_string_replace_first_test_6(void)
 }
 
 
-static void inquery_string_replace_first_test_7(void)
+/*
+ * replace_first_7() - test case #7 for inquery_string_replace_first()
+ */
+static void replace_first_7(void)
 {
     printf("inquery_string_replace_first() replaces an entire ASCII string");
 
@@ -487,7 +607,10 @@ static void inquery_string_replace_first_test_7(void)
 }
 
 
-static void inquery_string_replace_first_test_8(void)
+/*
+ * replace_first_8() - test case #8 for inquery_string_replace_first()
+ */
+static void replace_first_8(void)
 {
     printf("inquery_string_replace_first() replaces an entire Unicode string");
 
@@ -500,7 +623,10 @@ static void inquery_string_replace_first_test_8(void)
 }
 
 
-static void inquery_string_replace_first_test_9(void)
+/*
+ * replace_first_9() - test case #9 for inquery_string_replace_first()
+ */
+static void replace_first_9(void)
 {
     printf("inquery_string_replace_first() has no effect if @ctx, @what, and"
             "@with are all the same");
@@ -515,7 +641,10 @@ static void inquery_string_replace_first_test_9(void)
 }
 
 
-static void inquery_string_replace_first_test_10(void)
+/*
+ * replace_first_10() - test case #10 for inquery_string_replace_first()
+ */
+static void replace_first_10(void)
 {
     printf("inquery_string_replace_first() can replace the first instance of"
             " the same sequence of characters");
@@ -529,7 +658,10 @@ static void inquery_string_replace_first_test_10(void)
 }
 
 
-static void inquery_string_replace_test_1(void)
+/*
+ * replace_1() - test case #1 for inquery_string_replace()
+ */
+static void replace_1(void)
 {
     printf("inquery_string_replace() replaces an ASCII character with a null"
             " character");
@@ -542,7 +674,10 @@ static void inquery_string_replace_test_1(void)
 }
 
 
-static void inquery_string_replace_test_2(void)
+/*
+ * replace_2() - test case #2 for inquery_string_replace()
+ */
+static void replace_2(void)
 {
     printf("inquery_string_replace() replaces a Unicode character with a null"
             " character");
@@ -555,7 +690,10 @@ static void inquery_string_replace_test_2(void)
 }
 
 
-static void inquery_string_replace_test_3(void)
+/*
+ * replace_3() - test case #3 for inquery_string_replace()
+ */
+static void replace_3(void)
 {
     printf("inquery_string_replace() replaces all the instances in an ASCII"
             " string");
@@ -568,7 +706,10 @@ static void inquery_string_replace_test_3(void)
 }
 
 
-static void inquery_string_replace_test_4(void)
+/*
+ * replace_4() - test case #4 for inquery_string_replace()
+ */
+static void replace_4(void)
 {
     printf("inquery_string_replace() replaces all the instances in a Unicode"
             " string");
@@ -581,7 +722,10 @@ static void inquery_string_replace_test_4(void)
 }
 
 
-static void inquery_string_replace_test_5(void)
+/*
+ * replace_5() - test case #5 for inquery_string_replace()
+ */
+static void replace_5(void)
 {
     printf("inquery_string_replace() replaces an ASCII substring");
     
@@ -593,7 +737,10 @@ static void inquery_string_replace_test_5(void)
 }
 
 
-static void inquery_string_replace_test_6(void)
+/*
+ * replace_6() - test case #6 for inquery_string_replace()
+ */
+static void replace_6(void)
 {
     printf("inquery_string_replace() replaces a Unicode substring");
     
@@ -605,7 +752,10 @@ static void inquery_string_replace_test_6(void)
 }
 
 
-static void inquery_string_replace_test_7(void)
+/*
+ * replace_7() - test case #7 for inquery_string_replace()
+ */
+static void replace_7(void)
 {
     printf("inquery_string_replace() replaces an entire ASCII string");
     
@@ -618,7 +768,10 @@ static void inquery_string_replace_test_7(void)
 }
 
 
-static void inquery_string_replace_test_8(void)
+/*
+ * replace_8() - test case #8 for inquery_string_replace()
+ */
+static void replace_8(void)
 {
     printf("inquery_string_replace() replaces an entire Unicode string");
     
@@ -631,7 +784,10 @@ static void inquery_string_replace_test_8(void)
 }
 
 
-static void inquery_string_replace_test_9(void)
+/*
+ * replace_9() - test case #9 for inquery_string_replace()
+ */
+static void replace_9(void)
 {
     printf("inquery_string_replace() has no effect if @ctx, @what, and @with"
             " are all the same");
@@ -646,7 +802,10 @@ static void inquery_string_replace_test_9(void)
 }
 
 
-static void inquery_string_replace_test_10(void)
+/*
+ * replace_10() - test case #10 for inquery_string_replace()
+ */
+static void replace_10(void)
 {
     printf("inquery_string_replace() can replace all instance of the same"
             " sequence of characters");
@@ -660,72 +819,75 @@ static void inquery_string_replace_test_10(void)
 }
 
 
+/*
+ * inquery_test_suite_string() - string interface test suite
+ */
 extern void inquery_test_suite_string(void)
 {
     printf("===============================================================\n");
     printf("Starting string interface test suite...\n\n");
 
-    test_new_empty_1();
-    test_new_1();
-    test_new_2();
+    new_empty_1();
+    new_1();
+    new_2();
 
-    test_copy_1();
-    test_copy_2();
-    test_copy_3();
+    copy_1();
+    copy_2();
+    copy_3();
 
-    test_len_1();
-    test_len_2();
-    test_len_3();
+    len_1();
+    len_2();
+    len_3();
 
-    test_sz_1();
-    test_sz_2();
-    test_sz_3();
+    sz_1();
+    sz_2();
+    sz_3();
 
-    test_cmp_1();
-    test_cmp_2();
-    test_cmp_3();
-    test_cmp_4();
-    test_cmp_5();
-    test_cmp_6();
-    test_cmp_7();
-    test_cmp_8();
-    test_cmp_9();
+    cmp_1();
+    cmp_2();
+    cmp_3();
+    cmp_4();
+    cmp_5();
+    cmp_6();
+    cmp_7();
+    cmp_8();
+    cmp_9();
 
-    test_add_1();
-    test_add_2();
-    test_add_3();
+    add_1();
+    add_2();
+    add_3();
 
-    test_find_1();
-    test_find_2();
-    test_find_3();
-    test_find_4();
-    test_find_5();
-    test_find_6();
-    test_find_7();
-    test_find_8();
-    test_find_9();
+    find_1();
+    find_2();
+    find_3();
+    find_4();
+    find_5();
+    find_6();
+    find_7();
+    find_8();
+    find_9();
 
-    inquery_string_replace_first_test_1();
-    inquery_string_replace_first_test_2();
-    inquery_string_replace_first_test_3();
-    inquery_string_replace_first_test_4();
-    inquery_string_replace_first_test_5();
-    inquery_string_replace_first_test_6();
-    inquery_string_replace_first_test_7();
-    inquery_string_replace_first_test_8();
-    inquery_string_replace_first_test_9();
-    inquery_string_replace_first_test_10();
+    replace_first_1();
+    replace_first_2();
+    replace_first_3();
+    replace_first_4();
+    replace_first_5();
+    replace_first_6();
+    replace_first_7();
+    replace_first_8();
+    replace_first_9();
+    replace_first_10();
 
-    inquery_string_replace_test_1();
-    inquery_string_replace_test_2();
-    inquery_string_replace_test_3();
-    inquery_string_replace_test_4();
-    inquery_string_replace_test_5();
-    inquery_string_replace_test_6();
-    inquery_string_replace_test_7();
-    inquery_string_replace_test_8();
-    inquery_string_replace_test_9();
-    inquery_string_replace_test_10();
+    replace_1();
+    replace_2();
+    replace_3();
+    replace_4();
+    replace_5();
+    replace_6();
+    replace_7();
+    replace_8();
+    replace_9();
+    replace_10();
 
     printf("\n");
 }

--- a/test/string.c
+++ b/test/string.c
@@ -398,6 +398,137 @@ static void test_find_9(void)
 }
 
 
+static void inquery_string_replace_first_test_1(void)
+{
+    printf("inquery_string_replace_first() replaces an ASCII character with a null"
+            " character");
+
+    inquery_string *test = inquery_string_new("Hello, world!");
+    inquery_string_replace_first(&test, "!", "");
+    inquery_require (!strcmp(test, "Hello, world"));
+
+    printf("...OK\n");
+}
+
+
+static void inquery_string_replace_first_test_2(void)
+{
+    printf("inquery_string_replace_first() replaces a Unicode character with a"
+            " null character");
+
+    inquery_string *test = inquery_string_new("Привет, мир!");
+    inquery_string_replace_first(&test, "т", "");
+    inquery_require (!strcmp(test, "Приве, мир!"));
+
+    printf("...OK\n");
+}
+
+
+static void inquery_string_replace_first_test_3(void)
+{
+    printf("inquery_string_replace_first() replaces only the first instance in an"
+            " ASCII string");
+
+    inquery_string *test = inquery_string_new("Hello, world!");
+    inquery_string_replace_first(&test, "l", "y");
+    inquery_require (!strcmp(test, "Heylo, world!"));
+    
+    printf("OK");
+}
+
+
+static void inquery_string_replace_first_test_4(void)
+{
+    printf("inquery_string_replace_first() replaces only the first instance in a"
+            " Unicode string");
+
+    inquery_string *test = inquery_string_new("Привет, мир!");
+    inquery_string_replace_first(&test, "р", "r");
+    inquery_require (!strcmp(test, "Пrивет, мир!"));
+    
+    printf("...OK\n");
+}
+
+
+static void inquery_string_replace_first_test_5(void)
+{
+    printf("inquery_string_replace_first() replaces an ASCII substring");
+
+    inquery_string *test = inquery_string_new("Hello, world!");
+    inquery_string_replace_first(&test, "world", "moon");
+    inquery_require (!strcmp(test, "Hello, moon!"));
+
+    printf("OK");
+}
+
+
+static void inquery_string_replace_first_test_6(void)
+{
+    printf("inquery_string_replace_first() replaces a Unicode substring");
+
+    inquery_string_smart *test = inquery_string_new("Привет, мир!");
+    inquery_string_replace_first(&test, "Привет", "До свидания");
+    inquery_require (!strcmp(test, "До свидания, мир!"));
+    
+    printf("...OK\n");
+}
+
+
+static void inquery_string_replace_first_test_7(void)
+{
+    printf("inquery_string_replace_first() replaces an entire ASCII string");
+
+    const inquery_string *expect = "Goodbye, moon?";
+    inquery_string_smart *test = inquery_string_new("Hello, world!");
+    inquery_string_replace_first(&test, "Hello, world!", expect);
+    inquery_require (!strcmp(test, expect));
+
+    printf("...OK\n");
+}
+
+
+static void inquery_string_replace_first_test_8(void)
+{
+    printf("inquery_string_replace_first() replaces an entire Unicode string");
+
+    const inquery_string *expect = "До свидания, луна?";
+    inquery_string_smart *test = inquery_string_new("Привет, мир!");
+    inquery_string_replace_first(&test, "Привет, мир!", expect);
+    inquery_require (!strcmp(test, expect));
+    
+    printf("...OK\n");
+}
+
+
+static void inquery_string_replace_first_test_9(void)
+{
+    printf("inquery_string_replace_first() has no effect if @ctx, @what, and"
+            "@with are all the same");
+
+    inquery_string_smart *test = inquery_string_new("Hello, world!");
+    inquery_string_smart *what = inquery_string_new("Hello, world!");
+    inquery_string_smart *with = inquery_string_new("Hello, world!");
+    inquery_string_replace_first(&test, what, with);
+    inquery_require (!strcmp(test, what));
+    
+    printf("...OK\n");
+}
+
+
+static void inquery_string_replace_first_test_10(void)
+{
+    printf("inquery_string_replace_first() can replace the first instance of"
+            " the same sequence of characters");
+
+    inquery_string_smart *test = inquery_string_new("Hello, world!");
+    inquery_string_smart *expect = inquery_string_new("Helllo, world!");
+    inquery_string_replace_first(&test, "l", "ll");
+    inquery_require (!inquery_string_cmp(test, expect));
+
+    printf("...OK\n");
+}
+
+
 extern void inquery_test_suite_string(void)
 {
     printf("===============================================================\n");
@@ -442,6 +573,17 @@ extern void inquery_test_suite_string(void)
     test_find_7();
     test_find_8();
     test_find_9();
+
+    inquery_string_replace_first_test_1();
+    inquery_string_replace_first_test_2();
+    inquery_string_replace_first_test_3();
+    inquery_string_replace_first_test_4();
+    inquery_string_replace_first_test_5();
+    inquery_string_replace_first_test_6();
+    inquery_string_replace_first_test_7();
+    inquery_string_replace_first_test_8();
+    inquery_string_replace_first_test_9();
+    inquery_string_replace_first_test_10();
 
     printf("\n");
 }

--- a/test/string.c
+++ b/test/string.c
@@ -403,7 +403,7 @@ static void inquery_string_replace_first_test_1(void)
     printf("inquery_string_replace_first() replaces an ASCII character with a null"
             " character");
 
-    inquery_string *test = inquery_string_new("Hello, world!");
+    inquery_string_smart *test = inquery_string_new("Hello, world!");
     inquery_string_replace_first(&test, "!", "");
     inquery_require (!strcmp(test, "Hello, world"));
 
@@ -416,7 +416,7 @@ static void inquery_string_replace_first_test_2(void)
     printf("inquery_string_replace_first() replaces a Unicode character with a"
             " null character");
 
-    inquery_string *test = inquery_string_new("Привет, мир!");
+    inquery_string_smart *test = inquery_string_new("Привет, мир!");
     inquery_string_replace_first(&test, "т", "");
     inquery_require (!strcmp(test, "Приве, мир!"));
 
@@ -429,11 +429,11 @@ static void inquery_string_replace_first_test_3(void)
     printf("inquery_string_replace_first() replaces only the first instance in an"
             " ASCII string");
 
-    inquery_string *test = inquery_string_new("Hello, world!");
+    inquery_string_smart *test = inquery_string_new("Hello, world!");
     inquery_string_replace_first(&test, "l", "y");
     inquery_require (!strcmp(test, "Heylo, world!"));
     
-    printf("OK");
+    printf("...OK\n");
 }
 
 
@@ -442,7 +442,7 @@ static void inquery_string_replace_first_test_4(void)
     printf("inquery_string_replace_first() replaces only the first instance in a"
             " Unicode string");
 
-    inquery_string *test = inquery_string_new("Привет, мир!");
+    inquery_string_smart *test = inquery_string_new("Привет, мир!");
     inquery_string_replace_first(&test, "р", "r");
     inquery_require (!strcmp(test, "Пrивет, мир!"));
     
@@ -454,11 +454,11 @@ static void inquery_string_replace_first_test_5(void)
 {
     printf("inquery_string_replace_first() replaces an ASCII substring");
 
-    inquery_string *test = inquery_string_new("Hello, world!");
+    inquery_string_smart *test = inquery_string_new("Hello, world!");
     inquery_string_replace_first(&test, "world", "moon");
     inquery_require (!strcmp(test, "Hello, moon!"));
 
-    printf("OK");
+    printf("...OK\n");
 }
 
 

--- a/test/string.c
+++ b/test/string.c
@@ -1,0 +1,446 @@
+#include <string.h>
+#include "../lib/core/core.h"
+#include "suite.h"
+
+
+static void test_new_empty_1(void)
+{
+    printf("inquery_string_new_empty() can create an empty string...");
+
+    inquery_string_smart *test = inquery_string_new_empty();
+    inquery_require (test && !*test);
+
+    printf("OK\n");
+}
+
+
+static void test_new_1(void)
+{
+    printf("inquery_string_new() can create an ASCII string...");
+
+    const inquery_string *expect = "Hello, world!";
+    inquery_string_smart *test = inquery_string_new(expect);
+    inquery_require (test && !strcmp(test, expect));
+
+    printf("OK\n");
+}
+
+
+static void test_new_2(void)
+{
+    printf("inquery_string_new() can create a Unicode string...");
+
+    const inquery_string *expect = "Привет, мир!";
+    inquery_string_smart *test = inquery_string_new(expect);
+    inquery_require (test && !strcmp(test, expect));
+
+    printf("OK\n");
+}
+
+static void test_copy_1(void)
+{
+    printf("inquery_string_copy() can copy an empty string...");
+
+    inquery_string_smart *test = inquery_string_new_empty();
+    inquery_string_smart *copy = inquery_string_copy(test);
+    inquery_require (copy && !*copy);
+
+    printf("OK\n");
+}
+
+
+static void test_copy_2(void)
+{
+    printf("inquery_string_copy() can copy an ASCII string...");
+
+    const inquery_string *expect = "Hello, world!";
+    inquery_string_smart *test = inquery_string_new(expect);
+    inquery_string_smart *copy = inquery_string_copy(test);
+    inquery_require (test && !strcmp(copy, expect));
+
+    printf("OK\n");
+}
+
+
+static void test_copy_3(void)
+{
+    printf("inquery_string_copy() can copy a Unicode string...");
+
+    const inquery_string *expect = "Привет, мир!";
+    inquery_string_smart *test = inquery_string_new(expect);
+    inquery_string_smart *copy = inquery_string_copy(test);
+    inquery_require (test && !strcmp(copy, expect));
+
+    printf("OK\n");
+}
+
+
+static void test_len_1(void)
+{
+    printf("inquery_string_len() reports 0 for a null string...");
+
+    inquery_string_smart *test = inquery_string_new_empty();
+    inquery_require (inquery_string_len(test) == 0);
+
+    printf("OK\n");
+}
+
+
+static void test_len_2(void)
+{
+    printf("inquery_string_len() reports the length of an ASCII string...");
+
+    inquery_string_smart *test = inquery_string_new("Hello, world!");
+    inquery_require (inquery_string_len(test) == 13);
+
+    printf("OK\n");
+}
+
+
+static void test_len_3(void)
+{
+    printf("inquery_string_len() reports the length of a Unicode string...");
+
+    inquery_string_smart *test = inquery_string_new("Привет, мир!");
+    inquery_require (inquery_string_len(test) == 12);
+
+    printf("OK\n");
+}
+
+
+static void test_sz_1(void)
+{
+    printf("inquery_string_sz() reports 1 for a null string...");
+
+    inquery_string_smart *test = inquery_string_new_empty();
+    inquery_require (inquery_string_sz(test) == 1);
+
+    printf("OK\n");
+}
+
+
+static void test_sz_2(void)
+{
+    printf("inquery_string_sz() reports the size of an ASCII string...");
+
+    const inquery_string *sample = "Hello, world!";
+    inquery_string_smart *test = inquery_string_new(sample);
+    inquery_require (inquery_string_sz(test) == strlen(sample) + 1);
+
+    printf("OK\n");
+}
+
+
+static void test_sz_3(void)
+{
+    printf("inquery_string_sz() reports the size of a Unicode string...");
+
+    const inquery_string *sample = "Привет, мир!";
+    inquery_string_smart *test = inquery_string_new(sample);
+    inquery_require (inquery_string_sz(test) == strlen(sample) + 1);
+
+    printf("OK\n");
+}
+
+
+static void test_cmp_1(void)
+{
+    printf("inquery_string_cmp() detects two equal null strings...");
+
+    inquery_string_smart *lhs = inquery_string_new_empty();
+    inquery_string_smart *rhs = inquery_string_new_empty();
+    inquery_require (!inquery_string_cmp(lhs, rhs));
+
+    printf("OK\n");
+}
+
+
+static void test_cmp_2(void)
+{
+    printf("inquery_string_cmp() detects two equal ASCII strings...");
+
+    inquery_string_smart *lhs = inquery_string_new("Hello, world!");
+    inquery_string_smart *rhs = inquery_string_new("Hello, world!");
+    inquery_require (!inquery_string_cmp(lhs, rhs));
+
+    printf("OK\n");
+}
+
+
+static void test_cmp_3(void)
+{
+    printf("inquery_string_cmp() detects two equal Unicode strings...");
+
+    inquery_string_smart *lhs = inquery_string_new("Привет, мир!");
+    inquery_string_smart *rhs = inquery_string_new("Привет, мир!");
+    inquery_require (!inquery_string_cmp(lhs, rhs));
+
+    printf("OK\n");
+}
+
+static void test_cmp_4(void)
+{
+    printf("inquery_string_cmp() detects two unequal ASCII strings...");
+
+    inquery_string_smart *lhs = inquery_string_new("Hello, world!");
+    inquery_string_smart *rhs = inquery_string_new("Goodbye, moon?");
+    inquery_require (inquery_string_cmp(lhs, rhs));
+
+    printf("OK\n");;
+}
+
+
+static void test_cmp_5(void)
+{
+    printf("inquery_string_cmp() detects two unequal Unicode strings...");
+
+    inquery_string_smart *lhs = inquery_string_new("Привет, мир!");
+    inquery_string_smart *rhs = inquery_string_new("До свидания, луна?");
+    inquery_require (inquery_string_cmp(lhs, rhs));
+
+    printf("OK\n");;
+}
+
+
+static void test_cmp_6(void)
+{
+    printf("inquery_string_cmp() detects a lexicographically smaller ASCII"
+            " string...");
+
+    inquery_string_smart *lhs = inquery_string_new("Goodbye, moon?");
+    inquery_string_smart *rhs = inquery_string_new("Hello, world!");
+    inquery_require (inquery_string_cmp(lhs, rhs) < 0);
+
+    printf("OK\n");
+}
+
+
+static void test_cmp_7(void)
+{
+    printf("inquery_string_cmp() detects a lexicographically smaller Unicode"
+            " string...");
+
+    inquery_string_smart *lhs = inquery_string_new("До свидания, луна?");
+    inquery_string_smart *rhs = inquery_string_new("Привет, мир!");
+    inquery_require (inquery_string_cmp(lhs, rhs) < 0);
+
+    printf("OK\n");;
+}
+
+
+static void test_cmp_8(void)
+{
+    printf("inquery_string_cmp() detects a lexicographically greater ASCII"
+            "string...");
+
+    inquery_string_smart *lhs = inquery_string_new("Goodbye, moon?");
+    inquery_string_smart *rhs = inquery_string_new("Hello, world!");
+    inquery_require (inquery_string_cmp(rhs, lhs) > 0);
+
+    printf("OK\n");;
+}
+
+
+static void test_cmp_9(void)
+{
+    printf("inquery_string_cmp() detects a lexicographically greater Unicode"
+            " string...");
+
+    inquery_string_smart *lhs = inquery_string_new("До свидания, луна?");
+    inquery_string_smart *rhs = inquery_string_new("Привет, мир!");
+    inquery_require (inquery_string_cmp(rhs, lhs) > 0);
+
+    printf("OK\n");;
+}
+
+
+static void test_add_1(void)
+{
+    printf("inquery_string_add() adds two null strings...");
+
+    inquery_string_smart *test = inquery_string_new_empty();
+    inquery_string_add(&test, "");
+    inquery_require (!*test);
+
+    printf("OK\n");;
+}
+
+
+static void test_add_2(void)
+{
+    printf("inquery_string_add() adds two ASCII strings...");
+
+    inquery_string_smart *test = inquery_string_new("Hello");
+    inquery_string_add(&test, ", ");
+    inquery_string_add(&test, "world");
+    inquery_string_add(&test, "!");
+    inquery_require (!strcmp(test, "Hello, world!"));
+
+    printf("OK\n");;
+}
+
+
+static void test_add_3(void)
+{
+    printf("inquery_string_add() adds two Unicode strings...");
+
+    const inquery_string *expect = "До свидания, луна?";
+    inquery_string_smart *test = inquery_string_new("До свидания");
+    inquery_string_add(&test, ", ");
+    inquery_string_add(&test, "луна");
+    inquery_string_add(&test, "?");
+    inquery_require (!strcmp(test, expect));
+
+    printf("OK\n");;
+}
+
+
+static void test_find_1(void)
+{
+    printf("inquery_string_find() can find a null string");
+
+    inquery_string_smart *test = inquery_string_new_empty();
+    inquery_require (inquery_string_find(test, "") == 1);
+
+    printf("...OK\n");
+}
+
+
+static void test_find_2(void)
+{
+    printf("inquery_string_find() can find an ASCII string with 1 character");
+
+    inquery_string_smart *test = inquery_string_new("Hello, world!");
+    inquery_require (inquery_string_find(test, "w") == 8);
+
+    printf("...OK\n");
+}
+
+
+static void test_find_3(void)
+{
+    printf("inquery_string_find() can find a Unicode string with 1 character");
+
+    inquery_string_smart *test = inquery_string_new("Привет, мир!");
+    inquery_require (inquery_string_find(test, "м") == 9);
+
+    printf("...OK\n");
+}
+
+
+static void test_find_4(void)
+{
+    printf("inquery_string_find() can find an ASCII string");
+
+    inquery_string_smart *test = inquery_string_new("Hello, world!");
+    inquery_require (inquery_string_find(test, "world") == 8);
+
+    printf("...OK\n");
+}
+
+
+static void test_find_5(void)
+{
+    printf("inquery_string_find() can find a Unicode string");
+
+    inquery_string_smart *test = inquery_string_new("Привет, мир!");
+    inquery_require (inquery_string_find(test, "мир") == 9);
+
+    printf("...OK\n");
+}
+
+
+
+static void test_find_6(void)
+{
+    printf("inquery_string_find() can detect the absence of an ASCII string"
+            " with 1 character");
+
+    inquery_string_smart *test = inquery_string_new("Hello, world!");
+    inquery_require (inquery_string_find(test, "h") == 0);
+
+    printf("...OK\n");
+}
+
+
+static void test_find_7(void)
+{
+    printf("inquery_string_find() can detect the absence of a Unicode string"
+            " with 1 character");
+
+    inquery_string_smart *test = inquery_string_new("Привет, мир!");
+    inquery_require (inquery_string_find(test, "л") == 0);
+
+    printf("...OK\n");
+}
+
+
+static void test_find_8(void)
+{
+    printf("inquery_string_find() can detect the absence of an ASCII string");
+
+    inquery_string_smart *test = inquery_string_new("Hello, world!");
+    inquery_require (inquery_string_find(test, "moon") == 0);
+
+    printf("...OK\n");
+}
+
+
+static void test_find_9(void)
+{
+    printf("inquery_string_find() can detect the absence of a Unicode string");
+
+    inquery_string_smart *test = inquery_string_new("Привет, мир!"); 
+    inquery_require (inquery_string_find(test, "луна") == 0);
+
+    printf("...OK\n");
+}
+
+extern void inquery_test_suite_string(void)
+{
+    printf("===============================================================\n");
+    printf("Starting string interface test suite...\n\n");
+
+    test_new_empty_1();
+    test_new_1();
+    test_new_2();
+
+    test_copy_1();
+    test_copy_2();
+    test_copy_3();
+
+    test_len_1();
+    test_len_2();
+    test_len_3();
+
+    test_sz_1();
+    test_sz_2();
+    test_sz_3();
+
+    test_cmp_1();
+    test_cmp_2();
+    test_cmp_3();
+    test_cmp_4();
+    test_cmp_5();
+    test_cmp_6();
+    test_cmp_7();
+    test_cmp_8();
+    test_cmp_9();
+
+    test_add_1();
+    test_add_2();
+    test_add_3();
+
+    test_find_1();
+    test_find_2();
+    test_find_3();
+    test_find_4();
+    test_find_5();
+    test_find_6();
+    test_find_7();
+    test_find_8();
+    test_find_9();
+
+    printf("\n");
+}
+

--- a/test/suite.h
+++ b/test/suite.h
@@ -8,6 +8,12 @@ extern void inquery_test_suite_heap(void);
 
 
 /*
+ * inquery_test_suite_string) - string interface test suite
+ */
+extern void inquery_test_suite_string(void);
+
+
+/*
  * inquery_test_suite_object() - object model interface test suite
  */
 extern void inquery_test_suite_object(void);


### PR DESCRIPTION
The string interface has been created with the following functions:
  * `inquery_string_new()`
  * `inquery_string_new_empty()`
  * `inquery_string_copy()`
  * `inquery_string_free()`
  * `inquery_string_len()`
  * `inquery_string_sz()`
  * `inquery_string_cmp()`
  * `inquery_string_lt()`
  * `inquery_string_eq()`
  * `inquery_string_gt()`
  * `inquery_string_add()`
  * `inquery_string_find()`
  * `inquery_string_count()`
  * `inquery_string_replace()`
  * `inquery_string_replace_first()`

Supporting these functions are the `inquery_string` and `inquery_string_smart` types. Brief descriptions have been provided through comments wherever relevant, and a large number of unit tests have also been included.

Initially, the idea was to use the Simple Dynamic String library (of Redis fame), but I seemed not to have been able to use it successfully. However, I have still kept the SDS source files as I might give another shot at a later stage to incorporate this library into the string interface.

This pull request closes #8.