### PR TITLE
Create attribute interface

### DIFF
--- a/lib/core/attribute.c
+++ b/lib/core/attribute.c
@@ -87,14 +87,6 @@ extern inquery_value *inquery_attribute_value(const inquery_attribute *ctx)
 }
 
 
-extern bool inquery_attribute_nil(const inquery_attribute *ctx)
-{
-    inquery_assert (ctx);
-
-    const struct payload *payload = inquery_object_payload(ctx);
-    return inquery_value_nil(payload->val);
-}
-
 extern enum inquery_value_type inquery_attribute_type(
         const inquery_attribute *ctx)
 {
@@ -138,6 +130,42 @@ extern inline bool inquery_attribute_gteq(const inquery_attribute *ctx,
 
 extern inline bool inquery_attribute_gt(const inquery_attribute *ctx,
         const inquery_attribute *cmp);
+
+
+extern bool inquery_attribute_nil(const inquery_attribute *ctx)
+{
+    inquery_assert (ctx);
+
+    const struct payload *payload = inquery_object_payload(ctx);
+    return inquery_value_nil(payload->val);
+}
+
+
+extern int64_t inquery_attribute_int(const inquery_attribute *ctx)
+{
+    inquery_assert (ctx);
+
+    const struct payload *payload = inquery_object_payload(ctx);
+    return inquery_value_int(payload->val);
+}
+
+
+extern double inquery_attribute_real(const inquery_attribute *ctx)
+{
+    inquery_assert (ctx);
+
+    const struct payload *payload = inquery_object_payload(ctx);
+    return inquery_value_real(payload->val);
+}
+
+
+extern inquery_string *inquery_attribute_text(const inquery_attribute *ctx)
+{
+    inquery_assert (ctx);
+
+    const struct payload *payload = inquery_object_payload(ctx);
+    return inquery_value_text(payload->val);
+}
 
 
 extern inquery_string *inquery_attribute_string(const inquery_attribute *ctx)

--- a/lib/core/attribute.c
+++ b/lib/core/attribute.c
@@ -46,6 +46,22 @@ extern inquery_attribute *inquery_attribute_new(const inquery_string *key,
 }
 
 
+extern inline inquery_attribute *inquery_attribute_new_nil(
+        const inquery_string *key);
+
+
+extern inline inquery_attribute *inquery_attribute_new_int(
+        const inquery_string *key, int64_t val);
+
+
+extern inline inquery_attribute *inquery_attribute_new_real(
+        const inquery_string *key, double val);
+
+
+extern inline inquery_attribute *inquery_attribute_new_text(
+        const inquery_string *key, inquery_string *val);
+
+
 extern inline inquery_attribute *inquery_attribute_copy(
         const inquery_attribute *ctx);
 

--- a/lib/core/attribute.c
+++ b/lib/core/attribute.c
@@ -1,5 +1,3 @@
-#include <string.h>
-#include <inttypes.h>
 #include "core.h"
 
 
@@ -33,26 +31,6 @@ static void payload_free(void *ctx)
     struct payload *hnd = (struct payload *) ctx;
     inquery_string_free(&hnd->key);
     inquery_value_free(&hnd->val);
-}
-
-
-static inquery_string *from_int(int64_t val)
-{
-    size_t len = snprintf(NULL, 0, "%"PRId64, val) + 1;
-    inquery_string *str = inquery_heap_new(sizeof *str * len);
-    (void) snprintf(str, len, "%"PRId64, val);
-
-    return str;
-}
-
-
-static inquery_string *from_real(double val)
-{
-    size_t len = snprintf(NULL, 0, "%lf", val) + 1;
-    inquery_string *str = inquery_heap_new(sizeof *str * len);
-    snprintf(str, len, "%lf", val);
-
-    return str;
 }
 
 
@@ -121,24 +99,21 @@ inquery_string *inquery_attribute_json(const inquery_attribute *ctx)
     inquery_string_add(&json, "\":");
 
     switch (inquery_value_type(payload->val)) {
-        case INQUERY_VALUE_TYPE_NIL: {
-            inquery_string_add(&json, "(nil)");
-        } break;
-
         case INQUERY_VALUE_TYPE_INT: {
-            inquery_string_smart *str = from_int(inquery_value_int(
-                    payload->val));
+            inquery_string_smart *str = inquery_value_string(payload->val);
             inquery_string_add(&json, str);
         } break;
 
         case INQUERY_VALUE_TYPE_REAL: {
-            inquery_string_smart *str = from_real(inquery_value_real(
-                    payload->val));
+            inquery_string_smart *str = inquery_value_string(payload->val);
             inquery_string_add(&json, str);
         } break;
 
         default: {
-            inquery_string_add(&json, inquery_value_text(payload->val));
+            inquery_string_smart *str = inquery_value_string(payload->val);
+            inquery_string_add(&json, "\"");
+            inquery_string_add(&json, str);
+            inquery_string_add(&json, "\"");
         } break;
     }
 

--- a/lib/core/attribute.c
+++ b/lib/core/attribute.c
@@ -88,6 +88,41 @@ enum inquery_value_type inquery_attribute_type(const inquery_attribute *ctx)
 }
 
 
+extern int inquery_attribute_cmp(const inquery_attribute *ctx,
+        const inquery_attribute *cmp)
+{
+    inquery_assert (ctx && cmp);
+    inquery_assert (inquery_attribute_type(ctx) && inquery_attribute_type(cmp));
+    inquery_assert (inquery_attribute_type(ctx) == inquery_attribute_type(cmp));
+
+    const struct payload *ctxl = inquery_object_payload(ctx);
+    const struct payload *cmpl = inquery_object_payload(cmp);
+    inquery_assert (inquery_string_eq(ctxl->key, cmpl->key));
+
+    return inquery_value_cmp(ctxl->val, cmpl->val);
+}
+
+
+extern inline bool inquery_attribute_lt(const inquery_attribute *ctx, 
+        const inquery_attribute *cmp);
+
+
+extern inline bool inquery_attribute_lteq(const inquery_attribute *ctx,
+        const inquery_attribute *cmp);
+
+
+extern inline bool inquery_attribute_eq(const inquery_attribute *ctx,
+        const inquery_attribute *cmp);
+
+
+extern inline bool inquery_attribute_gteq(const inquery_attribute *ctx,
+        const inquery_attribute *cmp);
+
+
+extern inline bool inquery_attribute_gt(const inquery_attribute *ctx,
+        const inquery_attribute *cmp);
+
+
 inquery_string *inquery_attribute_json(const inquery_attribute *ctx)
 {
     inquery_assert (ctx);

--- a/lib/core/attribute.c
+++ b/lib/core/attribute.c
@@ -124,6 +124,20 @@ extern inline bool inquery_attribute_gt(const inquery_attribute *ctx,
         const inquery_attribute *cmp);
 
 
+extern inquery_string *inquery_attribute_string(const inquery_attribute *ctx)
+{
+    const struct payload *payload = inquery_object_payload(ctx);
+
+    inquery_string *str = inquery_string_new(payload->key);
+    inquery_string_add(&str, " = ");
+    
+    inquery_string_smart *val = inquery_value_string(payload->val);
+    inquery_string_add(&str, val);
+
+    return str;
+}
+
+
 extern inquery_string *inquery_attribute_json(const inquery_attribute *ctx)
 {
     inquery_assert (ctx);

--- a/lib/core/attribute.c
+++ b/lib/core/attribute.c
@@ -1,0 +1,147 @@
+#include <string.h>
+#include <inttypes.h>
+#include "core.h"
+
+
+struct payload {
+    inquery_string *key;
+    inquery_value *val;
+};
+
+
+static struct payload *payload_new(const inquery_string *key, 
+        const inquery_value *val)
+{
+    struct payload *ctx = inquery_heap_new(sizeof *ctx);
+
+    ctx->key = inquery_string_copy(key);
+    ctx->val = inquery_value_copy(val);
+
+    return ctx;
+}
+
+
+static void *payload_copy(const void *ctx)
+{
+    const struct payload *src = (const struct payload *) ctx;
+    return payload_new(src->key, src->val);
+}
+
+
+static void payload_free(void *ctx)
+{
+    struct payload *hnd = (struct payload *) ctx;
+    inquery_string_free(&hnd->key);
+    inquery_value_free(&hnd->val);
+}
+
+
+static inquery_string *from_int(int64_t val)
+{
+    size_t len = snprintf(NULL, 0, "%"PRId64, val) + 1;
+    inquery_string *str = inquery_heap_new(sizeof *str * len);
+    (void) snprintf(str, len, "%"PRId64, val);
+
+    return str;
+}
+
+
+static inquery_string *from_real(double val)
+{
+    size_t len = snprintf(NULL, 0, "%lf", val) + 1;
+    inquery_string *str = inquery_heap_new(sizeof *str * len);
+    snprintf(str, len, "%lf", val);
+
+    return str;
+}
+
+
+extern inquery_attribute *inquery_attribute_new(const inquery_string *key, 
+         const inquery_value *val)
+{
+    struct inquery_object_vtable vt = {
+            .payload_copy = &payload_copy,
+            .payload_free = &payload_free
+    };
+
+    return inquery_object_new(payload_new(key, val), &vt);
+}
+
+
+extern inline inquery_attribute *inquery_attribute_copy(
+        const inquery_attribute *ctx);
+
+
+extern inline void inquery_attribute_free(inquery_attribute **ctx);
+
+
+inquery_string *inquery_attribute_key(const inquery_attribute *ctx)
+{
+    inquery_assert (ctx);
+
+    const struct payload *payload = inquery_object_payload(ctx);
+    return inquery_string_copy(payload->key);
+}
+
+
+inquery_value *inquery_attribute_value(const inquery_attribute *ctx)
+{
+    inquery_assert (ctx);
+
+    const struct payload *payload = inquery_object_payload(ctx);
+    return inquery_value_copy(payload->val);
+}
+
+
+bool inquery_attribute_nil(const inquery_attribute *ctx)
+{
+    inquery_assert (ctx);
+
+    const struct payload *payload = inquery_object_payload(ctx);
+    return inquery_value_nil(payload->val);
+}
+
+enum inquery_value_type inquery_attribute_type(const inquery_attribute *ctx)
+{
+    inquery_assert (ctx);
+
+    const struct payload *payload = inquery_object_payload(ctx);
+    return inquery_value_type(payload->val);
+}
+
+
+inquery_string *inquery_attribute_json(const inquery_attribute *ctx)
+{
+    inquery_assert (ctx);
+
+    const struct payload *payload = inquery_object_payload(ctx);
+
+    inquery_string *json = inquery_string_new("\"");
+    inquery_string_add(&json, payload->key);
+    inquery_string_add(&json, "\":");
+
+    switch (inquery_value_type(payload->val)) {
+        case INQUERY_VALUE_TYPE_NIL: {
+            inquery_string_add(&json, "(nil)");
+        } break;
+
+        case INQUERY_VALUE_TYPE_INT: {
+            inquery_string_smart *str = from_int(inquery_value_int(
+                    payload->val));
+            inquery_string_add(&json, str);
+        } break;
+
+        case INQUERY_VALUE_TYPE_REAL: {
+            inquery_string_smart *str = from_real(inquery_value_real(
+                    payload->val));
+            inquery_string_add(&json, str);
+        } break;
+
+        default: {
+            inquery_string_add(&json, inquery_value_text(payload->val));
+        } break;
+    }
+
+    return json;
+}
+

--- a/lib/core/attribute.c
+++ b/lib/core/attribute.c
@@ -171,14 +171,7 @@ extern inquery_string *inquery_attribute_text(const inquery_attribute *ctx)
 extern inquery_string *inquery_attribute_string(const inquery_attribute *ctx)
 {
     const struct payload *payload = inquery_object_payload(ctx);
-
-    inquery_string *str = inquery_string_new(payload->key);
-    inquery_string_add(&str, " = ");
-    
-    inquery_string_smart *val = inquery_value_string(payload->val);
-    inquery_string_add(&str, val);
-
-    return str;
+    return inquery_value_string(ctx);
 }
 
 

--- a/lib/core/attribute.c
+++ b/lib/core/attribute.c
@@ -1,12 +1,18 @@
 #include "core.h"
 
 
+/*
+ * struct payload - object payload for attribute instance
+ */
 struct payload {
     inquery_string *key;
     inquery_value *val;
 };
 
 
+/*
+ * payload_new() - create new payload for attribute instance
+ */
 static struct payload *payload_new(const inquery_string *key, 
         const inquery_value *val)
 {
@@ -19,6 +25,9 @@ static struct payload *payload_new(const inquery_string *key,
 }
 
 
+/*
+ * payload_copy() - copy callback function for attribute v-table
+ */
 static void *payload_copy(const void *ctx)
 {
     const struct payload *src = (const struct payload *) ctx;
@@ -26,6 +35,9 @@ static void *payload_copy(const void *ctx)
 }
 
 
+/*
+ * payload_free() - free callback function for attribute v-table
+ */
 static void payload_free(void *ctx)
 {
     struct payload *hnd = (struct payload *) ctx;
@@ -34,6 +46,9 @@ static void payload_free(void *ctx)
 }
 
 
+/*
+ * inquery_attribute_new() - create new attribute
+ */
 extern inquery_attribute *inquery_attribute_new(const inquery_string *key, 
          const inquery_value *val)
 {
@@ -46,29 +61,50 @@ extern inquery_attribute *inquery_attribute_new(const inquery_string *key,
 }
 
 
+/*
+ * inquery_attribute_new_nil() - create new nil attribute
+ */
 extern inline inquery_attribute *inquery_attribute_new_nil(
         const inquery_string *key);
 
 
+/*
+ * inquery_attribute_new_int() - create new date attribute
+ */
 extern inline inquery_attribute *inquery_attribute_new_int(
         const inquery_string *key, int64_t val);
 
 
+/*
+ * inquery_attribute_new_real() - create new real attribute
+ */
 extern inline inquery_attribute *inquery_attribute_new_real(
         const inquery_string *key, double val);
 
 
+/*
+ * inquery_attribute_new_text() - create new text attribute
+ */
 extern inline inquery_attribute *inquery_attribute_new_text(
         const inquery_string *key, inquery_string *val);
 
 
+/*
+ * inquery_attribute_copy() - copy existing attribute
+ */
 extern inline inquery_attribute *inquery_attribute_copy(
         const inquery_attribute *ctx);
 
 
+/*
+ * inquery_attribute_free() - free attribute from heap
+ */
 extern inline void inquery_attribute_free(inquery_attribute **ctx);
 
 
+/*
+ * inquery_attribute_key() - get attribute key
+ */
 extern inquery_string *inquery_attribute_key(const inquery_attribute *ctx)
 {
     inquery_assert (ctx);
@@ -78,6 +114,9 @@ extern inquery_string *inquery_attribute_key(const inquery_attribute *ctx)
 }
 
 
+/*
+ * inquery_attribute_value() - get attribute value
+ */
 extern inquery_value *inquery_attribute_value(const inquery_attribute *ctx)
 {
     inquery_assert (ctx);
@@ -87,6 +126,9 @@ extern inquery_value *inquery_attribute_value(const inquery_attribute *ctx)
 }
 
 
+/*
+ * inquery_attribute_type() - get attribute type
+ */
 extern enum inquery_value_type inquery_attribute_type(
         const inquery_attribute *ctx)
 {
@@ -97,6 +139,9 @@ extern enum inquery_value_type inquery_attribute_type(
 }
 
 
+/*
+ * inquery_attribute_cmp() - compare two attributes
+ */
 extern int inquery_attribute_cmp(const inquery_attribute *ctx,
         const inquery_attribute *cmp)
 {
@@ -112,26 +157,44 @@ extern int inquery_attribute_cmp(const inquery_attribute *ctx,
 }
 
 
+/*
+ * inquery_attribute_lt() - check if attribute is < another
+ */
 extern inline bool inquery_attribute_lt(const inquery_attribute *ctx, 
         const inquery_attribute *cmp);
 
 
+/*
+ * inquery_attribute_lteq() - check if attribute is <= another
+ */
 extern inline bool inquery_attribute_lteq(const inquery_attribute *ctx,
         const inquery_attribute *cmp);
 
 
+/*
+ * inquery_attribute_eq() - check if attribute is == another
+ */
 extern inline bool inquery_attribute_eq(const inquery_attribute *ctx,
         const inquery_attribute *cmp);
 
 
+/*
+ * inquery_attribute_gteq() - check if attribute is >= another
+ */
 extern inline bool inquery_attribute_gteq(const inquery_attribute *ctx,
         const inquery_attribute *cmp);
 
 
+/*
+ * inquery_attribute_gt() - check if attribute is > another
+ */
 extern inline bool inquery_attribute_gt(const inquery_attribute *ctx,
         const inquery_attribute *cmp);
 
 
+/*
+ * inquery_attribute_nil() - check if attribute is nil
+ */
 extern bool inquery_attribute_nil(const inquery_attribute *ctx)
 {
     inquery_assert (ctx);
@@ -141,6 +204,9 @@ extern bool inquery_attribute_nil(const inquery_attribute *ctx)
 }
 
 
+/*
+ * inquery_attribute_int() - unbox integer attribute
+ */
 extern int64_t inquery_attribute_int(const inquery_attribute *ctx)
 {
     inquery_assert (ctx);
@@ -150,6 +216,9 @@ extern int64_t inquery_attribute_int(const inquery_attribute *ctx)
 }
 
 
+/*
+ * inquery_attribute_real() - unbox real attribute
+ */
 extern double inquery_attribute_real(const inquery_attribute *ctx)
 {
     inquery_assert (ctx);
@@ -159,6 +228,9 @@ extern double inquery_attribute_real(const inquery_attribute *ctx)
 }
 
 
+/*
+ * inquery_attribute_text() - unbox text attribute
+ */
 extern inquery_string *inquery_attribute_text(const inquery_attribute *ctx)
 {
     inquery_assert (ctx);
@@ -168,13 +240,19 @@ extern inquery_string *inquery_attribute_text(const inquery_attribute *ctx)
 }
 
 
+/*
+ * inquery_attribute_string() - represent attribute as string
+ */
 extern inquery_string *inquery_attribute_string(const inquery_attribute *ctx)
 {
     const struct payload *payload = inquery_object_payload(ctx);
-    return inquery_value_string(ctx);
+    return inquery_value_string(payload->val);
 }
 
 
+/*
+ * inquery_attribute_json() - represent attribute as JSON
+ */
 extern inquery_string *inquery_attribute_json(const inquery_attribute *ctx)
 {
     inquery_assert (ctx);

--- a/lib/core/attribute.c
+++ b/lib/core/attribute.c
@@ -53,7 +53,7 @@ extern inline inquery_attribute *inquery_attribute_copy(
 extern inline void inquery_attribute_free(inquery_attribute **ctx);
 
 
-inquery_string *inquery_attribute_key(const inquery_attribute *ctx)
+extern inquery_string *inquery_attribute_key(const inquery_attribute *ctx)
 {
     inquery_assert (ctx);
 
@@ -62,7 +62,7 @@ inquery_string *inquery_attribute_key(const inquery_attribute *ctx)
 }
 
 
-inquery_value *inquery_attribute_value(const inquery_attribute *ctx)
+extern inquery_value *inquery_attribute_value(const inquery_attribute *ctx)
 {
     inquery_assert (ctx);
 
@@ -71,7 +71,7 @@ inquery_value *inquery_attribute_value(const inquery_attribute *ctx)
 }
 
 
-bool inquery_attribute_nil(const inquery_attribute *ctx)
+extern bool inquery_attribute_nil(const inquery_attribute *ctx)
 {
     inquery_assert (ctx);
 
@@ -79,7 +79,8 @@ bool inquery_attribute_nil(const inquery_attribute *ctx)
     return inquery_value_nil(payload->val);
 }
 
-enum inquery_value_type inquery_attribute_type(const inquery_attribute *ctx)
+extern enum inquery_value_type inquery_attribute_type(
+        const inquery_attribute *ctx)
 {
     inquery_assert (ctx);
 
@@ -123,7 +124,7 @@ extern inline bool inquery_attribute_gt(const inquery_attribute *ctx,
         const inquery_attribute *cmp);
 
 
-inquery_string *inquery_attribute_json(const inquery_attribute *ctx)
+extern inquery_string *inquery_attribute_json(const inquery_attribute *ctx)
 {
     inquery_assert (ctx);
 

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -525,6 +525,39 @@ bool inquery_attribute_nil(const inquery_attribute *ctx);
 
 enum inquery_value_type inquery_attribute_type(const inquery_attribute *ctx);
 
+extern int inquery_attribute_cmp(const inquery_attribute *ctx,
+        const inquery_attribute *cmp);
+
+inline bool inquery_attribute_lt(const inquery_attribute *ctx, 
+        const inquery_attribute *cmp)
+{
+    return inquery_attribute_cmp(ctx, cmp) < 0;
+}
+
+inline bool inquery_attribute_lteq(const inquery_attribute *ctx,
+        const inquery_attribute *cmp)
+{
+    return inquery_attribute_cmp(ctx, cmp) <= 0;
+}
+
+inline bool inquery_attribute_eq(const inquery_attribute *ctx,
+        const inquery_attribute *cmp)
+{
+    return !inquery_attribute_cmp(ctx, cmp);
+}
+
+inline bool inquery_attribute_gteq(const inquery_attribute *ctx,
+        const inquery_attribute *cmp)
+{
+    return inquery_value_cmp(ctx, cmp) >= 0;
+}
+
+inline bool inquery_attribute_gt(const inquery_attribute *ctx,
+        const inquery_attribute *cmp)
+{
+    return inquery_attribute_cmp(ctx, cmp) > 0;
+}
+
 inquery_string *inquery_attribute_json(const inquery_attribute *ctx);
 
 

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -371,6 +371,8 @@ inline void inquery_value_free(inquery_value **ctx)
 
 extern bool inquery_value_nil(const inquery_value *ctx);
 
+extern enum inquery_value_type inquery_value_type(const inquery_value *ctx);
+
 extern uint64_t inquery_value_int(const inquery_value *ctx);
 
 extern double inquery_value_real(const inquery_value *ctx);

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -337,46 +337,109 @@ extern void *inquery_object_payload_mutable(inquery_object **ctx);
  */
 
 
+/*
+ * inquery_value - boxed value
+ */
 typedef inquery_object inquery_value;
 
+
+/*
+ * inquery_value_smart - smart boxed value
+ */
 #define inquery_value_smart inquery_object_smart
 
+
+/*
+ * enum inquery_value_type - enumerated value types
+ */
 enum inquery_value_type {
     INQUERY_VALUE_TYPE_INT,
     INQUERY_VALUE_TYPE_REAL,
     INQUERY_VALUE_TYPE_TEXT
 };
 
+
+/*
+ * inquery_value_new_int() - create new integer value
+ */
 extern inquery_value *inquery_value_new_int(uint64_t val);
 
+
+/*
+ * inquery_value_new_int_nil() - create new nil integer value
+ */
 extern inquery_value *inquery_value_new_int_nil(void);
 
+
+/*
+ * inquery_value_new_real() - create new real value
+ */
 extern inquery_value *inquery_value_new_real(double val);
 
+
+/*
+ * inquery_value_new_real_nil() - create new nil real value
+ */
 extern inquery_value *inquery_value_new_real_nil(void);
 
+
+/*
+ * inquery_value_new_text() - create new text value
+ */
 extern inquery_value *inquery_value_new_text(const inquery_string *val);
 
+
+/*
+ * inquery_value_new_text_nil() - create new nil text value
+ */
 extern inquery_value *inquery_value_new_text_nil(void);
 
+
+/*
+ * inquery_value_copy() - create copy of existing value
+ */
 inline inquery_value *inquery_value_copy(const inquery_value *ctx)
 {
     return inquery_object_copy(ctx);
 }
 
+
+/*
+ * inquery_value_free() - free value from heap
+ */
 inline void inquery_value_free(inquery_value **ctx)
 {
     inquery_object_free(ctx);
 }
 
+
+/*
+ * inquery_value_nil() - check if value is nil
+ */
 extern bool inquery_value_nil(const inquery_value *ctx);
 
+
+/*
+ * inquery_value_type() - get value type
+ */
 extern enum inquery_value_type inquery_value_type(const inquery_value *ctx);
 
+
+/*
+ * inquery_value_int() - unbox integer value
+ */
 extern uint64_t inquery_value_int(const inquery_value *ctx);
 
+
+/*
+ * inquery_value_real() - unbox real value
+ */
 extern double inquery_value_real(const inquery_value *ctx);
 
+
+/*
+ * inquery_value_string() - unbox string value
+ */
 extern inquery_string *inquery_value_text(const inquery_value *ctx);
 
 

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -507,6 +507,33 @@ typedef inquery_object inquery_attribute;
 extern inquery_attribute *inquery_attribute_new(const inquery_string *key, 
          const inquery_value *val);
 
+inline inquery_attribute *inquery_attribute_new_nil(const inquery_string *key)
+{
+    inquery_value_smart *val = inquery_value_new();
+    return inquery_attribute_new(key, val);
+}
+
+inline inquery_attribute *inquery_attribute_new_int(const inquery_string *key,
+        int64_t val)
+{
+    inquery_value_smart *v = inquery_value_new_int(val);
+    return inquery_attribute_new(key, v);
+}
+
+inline inquery_attribute *inquery_attribute_new_real(const inquery_string *key,
+        double val)
+{
+    inquery_value_smart *v = inquery_value_new_real(val);
+    return inquery_attribute_new(key, v);
+}
+
+inline inquery_attribute *inquery_attribute_new_text(const inquery_string *key,
+        inquery_string *val)
+{
+    inquery_value_smart *v = inquery_value_new_text(val);
+    return inquery_attribute_new(key, v);
+}
+
 inline inquery_attribute *inquery_attribute_copy(const inquery_attribute *ctx)
 {
     return inquery_object_copy(ctx);

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -517,13 +517,14 @@ inline void inquery_attribute_free(inquery_attribute **ctx)
     inquery_object_free(ctx);
 }
 
-inquery_string *inquery_attribute_key(const inquery_attribute *ctx);
+extern inquery_string *inquery_attribute_key(const inquery_attribute *ctx);
 
-inquery_value *inquery_attribute_value(const inquery_attribute *ctx);
+extern inquery_value *inquery_attribute_value(const inquery_attribute *ctx);
 
-bool inquery_attribute_nil(const inquery_attribute *ctx);
+extern bool inquery_attribute_nil(const inquery_attribute *ctx);
 
-enum inquery_value_type inquery_attribute_type(const inquery_attribute *ctx);
+extern enum inquery_value_type inquery_attribute_type(
+        const inquery_attribute *ctx);
 
 extern int inquery_attribute_cmp(const inquery_attribute *ctx,
         const inquery_attribute *cmp);
@@ -558,7 +559,7 @@ inline bool inquery_attribute_gt(const inquery_attribute *ctx,
     return inquery_attribute_cmp(ctx, cmp) > 0;
 }
 
-inquery_string *inquery_attribute_json(const inquery_attribute *ctx);
+extern inquery_string *inquery_attribute_json(const inquery_attribute *ctx);
 
 
 #endif /* INQUERY_CORE_HEADER_INCLUDED */

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -409,6 +409,63 @@ extern enum inquery_value_type inquery_value_type(const inquery_value *ctx);
 
 
 /*
+ * inquery_value_cmp() - comnpare two values
+ */
+extern int inquery_value_cmp(const inquery_value *ctx, 
+        const inquery_value *cmp);
+
+
+/*
+ * inquery_value_lt() - check if value is less than another
+ */
+inline bool inquery_value_lt(const inquery_value *ctx, 
+        const inquery_value *cmp)
+{
+    return inquery_value_cmp(ctx, cmp) < 0;
+}
+
+
+/*
+ * inquery_value_lteq() - check if value is less than or equal to another
+ */
+inline bool inquery_value_lteq(const inquery_value *ctx,
+        const inquery_value *cmp)
+{
+    return inquery_value_cmp(ctx, cmp) <= 0;
+}
+
+
+/*
+ * inquery_value_eq() - check if value is equal to another
+ */
+inline bool inquery_value_eq(const inquery_value *ctx,
+        const inquery_value *cmp)
+{
+    return !inquery_value_cmp(ctx, cmp);
+}
+
+
+/*
+ * inquery_value_gteq() - check if value is greater than or equal to another
+ */
+inline bool inquery_value_gteq(const inquery_value *ctx,
+        const inquery_value *cmp)
+{
+    return inquery_value_cmp(ctx, cmp) >= 0;
+}
+
+
+/*
+ * inquery_value_gt() - check if value is greater than another
+ */
+inline bool inquery_value_gt(const inquery_value *ctx,
+        const inquery_value *cmp)
+{
+    return inquery_value_cmp(ctx, cmp) > 0;
+}
+
+
+/*
  * inquery_value_nil() - check if value is nil
  */
 extern bool inquery_value_nil(const inquery_value *ctx);

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -559,6 +559,8 @@ inline bool inquery_attribute_gt(const inquery_attribute *ctx,
     return inquery_attribute_cmp(ctx, cmp) > 0;
 }
 
+extern inquery_string *inquery_attribute_string(const inquery_attribute *ctx);
+
 extern inquery_string *inquery_attribute_json(const inquery_attribute *ctx);
 
 

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -27,6 +27,7 @@
 
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -329,6 +330,85 @@ extern const void *inquery_object_payload(const inquery_object *ctx);
  * inquery_object_payload_mutable() - get mutable handle to object payload
  */
 extern void *inquery_object_payload_mutable(inquery_object **ctx);
+
+
+/*******************************************************************************
+ * VALUE
+ */
+
+
+typedef inquery_object inquery_value;
+
+#define inquery_value_smart inquery_object_smart
+
+enum inquery_value_type {
+    INQUERY_VALUE_TYPE_INT,
+    INQUERY_VALUE_TYPE_REAL,
+    INQUERY_VALUE_TYPE_TEXT
+};
+
+extern inquery_value *inquery_value_new_int(uint64_t val);
+
+extern inquery_value *inquery_value_new_int_nil(void);
+
+extern inquery_value *inquery_value_new_real(double val);
+
+extern inquery_value *inquery_value_new_real_nil(void);
+
+extern inquery_value *inquery_value_new_text(const inquery_string *val);
+
+extern inquery_value *inquery_value_new_text_nil(void);
+
+inline inquery_value *inquery_value_copy(const inquery_value *ctx)
+{
+    return inquery_object_copy(ctx);
+}
+
+inline void inquery_value_free(inquery_value **ctx)
+{
+    inquery_object_free(ctx);
+}
+
+extern bool inquery_value_nil(const inquery_value *ctx);
+
+extern uint64_t inquery_value_int(const inquery_value *ctx);
+
+extern double inquery_value_real(const inquery_value *ctx);
+
+extern inquery_string *inquery_value_text(const inquery_value *ctx);
+
+
+/*******************************************************************************
+ * ATTRIBUTE
+ */
+
+
+typedef inquery_object inquery_attribute;
+
+#define inquery_attribute_smart inquery_object_smart
+
+extern inquery_attribute *inquery_attribute_new(const inquery_string *key, 
+         inquery_value *val);
+
+inline inquery_attribute *inquery_attribute_copy(const inquery_attribute *ctx)
+{
+    return inquery_object_copy(ctx);
+}
+
+inline void inquery_attribute_free(inquery_attribute **ctx)
+{
+    inquery_object_free(ctx);
+}
+
+inquery_string *inquery_attribute_key(const inquery_attribute *ctx);
+
+inquery_value *inquery_attribute_value(const inquery_attribute *ctx);
+
+bool inquery_attribute_nil(const inquery_attribute *ctx);
+
+enum inquery_value_type inquery_attribute_type(const inquery_attribute *ctx);
+
+inquery_string *inquery_attribute_json(const inquery_attribute *ctx);
 
 
 #endif /* INQUERY_CORE_HEADER_INCLUDED */

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -353,10 +353,17 @@ typedef inquery_object inquery_value;
  * enum inquery_value_type - enumerated value types
  */
 enum inquery_value_type {
+    INQUERY_VALUE_TYPE_NIL,
     INQUERY_VALUE_TYPE_INT,
     INQUERY_VALUE_TYPE_REAL,
     INQUERY_VALUE_TYPE_TEXT
 };
+
+
+/*
+ * inquery_value_new() - create new nil value
+ */
+extern inquery_value *inquery_value_new(void);
 
 
 /*
@@ -366,33 +373,15 @@ extern inquery_value *inquery_value_new_int(int64_t val);
 
 
 /*
- * inquery_value_new_int_nil() - create new nil integer value
- */
-extern inquery_value *inquery_value_new_int_nil(void);
-
-
-/*
  * inquery_value_new_real() - create new real value
  */
 extern inquery_value *inquery_value_new_real(double val);
 
 
 /*
- * inquery_value_new_real_nil() - create new nil real value
- */
-extern inquery_value *inquery_value_new_real_nil(void);
-
-
-/*
  * inquery_value_new_text() - create new text value
  */
 extern inquery_value *inquery_value_new_text(const inquery_string *val);
-
-
-/*
- * inquery_value_new_text_nil() - create new nil text value
- */
-extern inquery_value *inquery_value_new_text_nil(void);
 
 
 /*
@@ -414,15 +403,15 @@ inline void inquery_value_free(inquery_value **ctx)
 
 
 /*
- * inquery_value_nil() - check if value is nil
- */
-extern bool inquery_value_nil(const inquery_value *ctx);
-
-
-/*
  * inquery_value_type() - get value type
  */
 extern enum inquery_value_type inquery_value_type(const inquery_value *ctx);
+
+
+/*
+ * inquery_value_nil() - check if value is nil
+ */
+extern bool inquery_value_nil(const inquery_value *ctx);
 
 
 /*
@@ -438,7 +427,7 @@ extern double inquery_value_real(const inquery_value *ctx);
 
 
 /*
- * inquery_value_string() - unbox string value
+ * inquery_value_text() - unbox text value
  */
 extern inquery_string *inquery_value_text(const inquery_value *ctx);
 

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -466,7 +466,7 @@ inline bool inquery_value_gt(const inquery_value *ctx,
 
 
 /*
- * inquery_value_nil() - check if value is nil
+ * inquery_value_nil() - create new nil value
  */
 extern bool inquery_value_nil(const inquery_value *ctx);
 
@@ -499,7 +499,7 @@ typedef inquery_object inquery_attribute;
 #define inquery_attribute_smart inquery_object_smart
 
 extern inquery_attribute *inquery_attribute_new(const inquery_string *key, 
-         inquery_value *val);
+         const inquery_value *val);
 
 inline inquery_attribute *inquery_attribute_copy(const inquery_attribute *ctx)
 {

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -500,19 +500,38 @@ extern inquery_string *inquery_value_string(const inquery_value *ctx);
  */
 
 
+/*
+ * inquery_attribute - entity attribute
+ */
 typedef inquery_object inquery_attribute;
 
+
+/*
+ * inquery_attribute_smart - smart attribute
+ */
 #define inquery_attribute_smart inquery_object_smart
 
+
+/*
+ * inquery_attribute_new() - create new attribute
+ */
 extern inquery_attribute *inquery_attribute_new(const inquery_string *key, 
          const inquery_value *val);
 
+
+/*
+ * inquery_attribute_new_nil() - create new nil attribute
+ */
 inline inquery_attribute *inquery_attribute_new_nil(const inquery_string *key)
 {
     inquery_value_smart *val = inquery_value_new();
     return inquery_attribute_new(key, val);
 }
 
+
+/*
+ * inquery_attribute_new_int() - create new date attribute
+ */
 inline inquery_attribute *inquery_attribute_new_int(const inquery_string *key,
         int64_t val)
 {
@@ -520,6 +539,10 @@ inline inquery_attribute *inquery_attribute_new_int(const inquery_string *key,
     return inquery_attribute_new(key, v);
 }
 
+
+/*
+ * inquery_attribute_new_real() - create new real attribute
+ */
 inline inquery_attribute *inquery_attribute_new_real(const inquery_string *key,
         double val)
 {
@@ -527,6 +550,10 @@ inline inquery_attribute *inquery_attribute_new_real(const inquery_string *key,
     return inquery_attribute_new(key, v);
 }
 
+
+/*
+ * inquery_attribute_new_text() - create new text attribute
+ */
 inline inquery_attribute *inquery_attribute_new_text(const inquery_string *key,
         inquery_string *val)
 {
@@ -534,66 +561,134 @@ inline inquery_attribute *inquery_attribute_new_text(const inquery_string *key,
     return inquery_attribute_new(key, v);
 }
 
+
+/*
+ * inquery_attribute_copy() - copy existing attribute
+ */
 inline inquery_attribute *inquery_attribute_copy(const inquery_attribute *ctx)
 {
     return inquery_object_copy(ctx);
 }
 
+
+/*
+ * inquery_attribute_free() - free attribute from heap
+ */
 inline void inquery_attribute_free(inquery_attribute **ctx)
 {
     inquery_object_free(ctx);
 }
 
+
+/*
+ * inquery_attribute_key() - get attribute key
+ */
 extern inquery_string *inquery_attribute_key(const inquery_attribute *ctx);
 
+
+/*
+ * inquery_attribute_value() - get attribute value
+ */
 extern inquery_value *inquery_attribute_value(const inquery_attribute *ctx);
 
+
+/*
+ * inquery_attribute_type() - get attribute type
+ */
 extern enum inquery_value_type inquery_attribute_type(
         const inquery_attribute *ctx);
 
+
+/*
+ * inquery_attribute_cmp() - compare two attributes
+ */
 extern int inquery_attribute_cmp(const inquery_attribute *ctx,
         const inquery_attribute *cmp);
 
+
+/*
+ * inquery_attribute_lt() - check if attribute is < another
+ */
 inline bool inquery_attribute_lt(const inquery_attribute *ctx, 
         const inquery_attribute *cmp)
 {
     return inquery_attribute_cmp(ctx, cmp) < 0;
 }
 
+
+/*
+ * inquery_attribute_lteq() - check if attribute is <= another
+ */
 inline bool inquery_attribute_lteq(const inquery_attribute *ctx,
         const inquery_attribute *cmp)
 {
     return inquery_attribute_cmp(ctx, cmp) <= 0;
 }
 
+
+/*
+ * inquery_attribute_eq() - check if attribute is == another
+ */
 inline bool inquery_attribute_eq(const inquery_attribute *ctx,
         const inquery_attribute *cmp)
 {
     return !inquery_attribute_cmp(ctx, cmp);
 }
 
+
+/*
+ * inquery_attribute_gteq() - check if attribute is >= another
+ */
 inline bool inquery_attribute_gteq(const inquery_attribute *ctx,
         const inquery_attribute *cmp)
 {
     return inquery_value_cmp(ctx, cmp) >= 0;
 }
 
+
+/*
+ * inquery_attribute_gt() - check if attribute is > another
+ */
 inline bool inquery_attribute_gt(const inquery_attribute *ctx,
         const inquery_attribute *cmp)
 {
     return inquery_attribute_cmp(ctx, cmp) > 0;
 }
 
+
+/*
+ * inquery_attribute_nil() - check if attribute is nil
+ */
 extern bool inquery_attribute_nil(const inquery_attribute *ctx);
 
+
+/*
+ * inquery_attribute_int() - unbox integer attribute
+ */
 extern int64_t inquery_attribute_int(const inquery_attribute *ctx);
 
+
+/*
+ * inquery_attribute_real() - unbox real attribute
+ */
 extern double inquery_attribute_real(const inquery_attribute *ctx);
 
+
+/*
+ * inquery_attribute_text() - unbox text attribute
+ */
 extern inquery_string *inquery_attribute_text(const inquery_attribute *ctx);
 
+
+/*
+ * inquery_attribute_string() - represent attribute as string
+ */
 extern inquery_string *inquery_attribute_string(const inquery_attribute *ctx);
 
+
+/*
+ * inquery_attribute_json() - represent attribute as JSON
+ */
 extern inquery_string *inquery_attribute_json(const inquery_attribute *ctx);
 
 

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -362,7 +362,7 @@ enum inquery_value_type {
 /*
  * inquery_value_new_int() - create new integer value
  */
-extern inquery_value *inquery_value_new_int(uint64_t val);
+extern inquery_value *inquery_value_new_int(int64_t val);
 
 
 /*
@@ -428,7 +428,7 @@ extern enum inquery_value_type inquery_value_type(const inquery_value *ctx);
 /*
  * inquery_value_int() - unbox integer value
  */
-extern uint64_t inquery_value_int(const inquery_value *ctx);
+extern int64_t inquery_value_int(const inquery_value *ctx);
 
 
 /*

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -548,8 +548,6 @@ extern inquery_string *inquery_attribute_key(const inquery_attribute *ctx);
 
 extern inquery_value *inquery_attribute_value(const inquery_attribute *ctx);
 
-extern bool inquery_attribute_nil(const inquery_attribute *ctx);
-
 extern enum inquery_value_type inquery_attribute_type(
         const inquery_attribute *ctx);
 
@@ -585,6 +583,14 @@ inline bool inquery_attribute_gt(const inquery_attribute *ctx,
 {
     return inquery_attribute_cmp(ctx, cmp) > 0;
 }
+
+extern bool inquery_attribute_nil(const inquery_attribute *ctx);
+
+extern int64_t inquery_attribute_int(const inquery_attribute *ctx);
+
+extern double inquery_attribute_real(const inquery_attribute *ctx);
+
+extern inquery_string *inquery_attribute_text(const inquery_attribute *ctx);
 
 extern inquery_string *inquery_attribute_string(const inquery_attribute *ctx);
 

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -466,7 +466,7 @@ inline bool inquery_value_gt(const inquery_value *ctx,
 
 
 /*
- * inquery_value_nil() - create new nil value
+ * inquery_value_nil() - check if value is nil
  */
 extern bool inquery_value_nil(const inquery_value *ctx);
 
@@ -487,6 +487,12 @@ extern double inquery_value_real(const inquery_value *ctx);
  * inquery_value_text() - unbox text value
  */
 extern inquery_string *inquery_value_text(const inquery_value *ctx);
+
+
+/*
+ * inquery_value_string() - get string representation of value
+ */
+extern inquery_string *inquery_value_string(const inquery_value *ctx);
 
 
 /*******************************************************************************

--- a/lib/core/value.c
+++ b/lib/core/value.c
@@ -2,6 +2,9 @@
 #include "core.h"
 
 
+/*
+ * struct payload - object payload for value instance
+ */
 struct payload {
     enum inquery_value_type type;
     size_t size;
@@ -9,6 +12,9 @@ struct payload {
 };
 
 
+/*
+ * payload_new() - create new payload for value instance
+ */
 static struct payload *payload_new(enum inquery_value_type type, size_t sz,
         const void *val)
 {
@@ -28,6 +34,9 @@ static struct payload *payload_new(enum inquery_value_type type, size_t sz,
 }
 
 
+/*
+ * payload_copy() - copy callback function for value v-table
+ */
 static void *payload_copy(const void *ctx)
 {
     const struct payload *src = (const struct payload *) ctx;
@@ -35,6 +44,9 @@ static void *payload_copy(const void *ctx)
 }
 
 
+/*
+ * payload_free() - free callback function for value v-table
+ */
 static void payload_free(void *ctx)
 {
     struct payload *hnd = (struct payload *) ctx;
@@ -42,6 +54,9 @@ static void payload_free(void *ctx)
 }
 
 
+/*
+ * inquery_value_new_int() - create new integer value
+ */
 extern inquery_value *inquery_value_new_int(uint64_t val)
 {
     struct inquery_object_vtable vt = {
@@ -54,6 +69,9 @@ extern inquery_value *inquery_value_new_int(uint64_t val)
 }
 
 
+/*
+ * inquery_value_new_int_nil() - create new nil integer value
+ */
 extern inquery_value *inquery_value_new_int_nil(void)
 {
     struct inquery_object_vtable vt = {
@@ -66,6 +84,9 @@ extern inquery_value *inquery_value_new_int_nil(void)
 }
 
 
+/*
+ * inquery_value_new_real() - create new real value
+ */
 extern inquery_value *inquery_value_new_real(double val)
 {
     struct inquery_object_vtable vt = {
@@ -78,6 +99,9 @@ extern inquery_value *inquery_value_new_real(double val)
 }
 
 
+/*
+ * inquery_value_new_real_nil() - create new nil real value
+ */
 extern inquery_value *inquery_value_new_real_nil(void)
 {
     struct inquery_object_vtable vt = {
@@ -90,6 +114,9 @@ extern inquery_value *inquery_value_new_real_nil(void)
 }
 
 
+/*
+ * inquery_value_new_text() - create new text value
+ */
 extern inquery_value *inquery_value_new_text(const inquery_string *val)
 {
     inquery_assert (val);
@@ -104,6 +131,9 @@ extern inquery_value *inquery_value_new_text(const inquery_string *val)
 }
 
 
+/*
+ * inquery_value_new_text_nil() - create new nil text value
+ */
 extern inquery_value *inquery_value_new_text_nil(void)
 {
     struct inquery_object_vtable vt = {
@@ -116,12 +146,21 @@ extern inquery_value *inquery_value_new_text_nil(void)
 }
 
 
+/*
+ * inquery_value_copy() - create copy of existing value
+ */
 extern inline inquery_value *inquery_value_copy(const inquery_value *ctx);
 
 
+/*
+ * inquery_value_free() - free value from heap
+ */
 extern inline void inquery_value_free(inquery_value **ctx);
 
 
+/*
+ * inquery_value_nil() - check if value is nil
+ */
 extern bool inquery_value_nil(const inquery_value *ctx)
 {
     inquery_assert (ctx);
@@ -131,6 +170,9 @@ extern bool inquery_value_nil(const inquery_value *ctx)
 }
 
 
+/*
+ * inquery_value_type() - get value type
+ */
 extern enum inquery_value_type inquery_value_type(const inquery_value *ctx)
 {
     inquery_assert (ctx);
@@ -140,6 +182,9 @@ extern enum inquery_value_type inquery_value_type(const inquery_value *ctx)
 }
 
 
+/*
+ * inquery_value_int() - unbox integer value
+ */
 extern uint64_t inquery_value_int(const inquery_value *ctx)
 {
     inquery_assert (ctx);
@@ -151,6 +196,9 @@ extern uint64_t inquery_value_int(const inquery_value *ctx)
 }
 
 
+/*
+ * inquery_value_real() - unbox real value
+ */
 extern double inquery_value_real(const inquery_value *ctx)
 {
     inquery_assert (ctx);
@@ -162,6 +210,9 @@ extern double inquery_value_real(const inquery_value *ctx)
 }
 
 
+/*
+ * inquery_value_string() - unbox string value
+ */
 extern inquery_string *inquery_value_text(const inquery_value *ctx)
 {
     inquery_assert (ctx);

--- a/lib/core/value.c
+++ b/lib/core/value.c
@@ -1,0 +1,174 @@
+#include <string.h>
+#include "core.h"
+
+
+struct payload {
+    enum inquery_value_type type;
+    size_t size;
+    void *value;
+};
+
+
+static struct payload *payload_new(enum inquery_value_type type, size_t sz,
+        const void *val)
+{
+    struct payload *ctx = inquery_heap_new(sizeof *ctx);
+
+    ctx->type = type;
+    ctx->size = sz;
+
+    if (inquery_likely (val)) {
+        ctx->value = inquery_heap_new(sz);
+        memcpy(ctx->value, val, sz);
+    } else {
+        ctx->value = NULL;
+    };
+
+    return ctx;
+}
+
+
+static void *payload_copy(const void *ctx)
+{
+    const struct payload *src = (const struct payload *) ctx;
+    return payload_new(src->type, src->size, src->value);
+}
+
+
+static void payload_free(void *ctx)
+{
+    struct payload *hnd = (struct payload *) ctx;
+    inquery_heap_free(&hnd->value);
+}
+
+
+extern inquery_value *inquery_value_new_int(uint64_t val)
+{
+    struct inquery_object_vtable vt = {
+        .payload_copy = &payload_copy,
+        .payload_free = &payload_free
+    };
+
+    return inquery_object_new(payload_new(INQUERY_VALUE_TYPE_INT, 
+            sizeof (uint64_t), &val), &vt);
+}
+
+
+extern inquery_value *inquery_value_new_int_nil(void)
+{
+    struct inquery_object_vtable vt = {
+        .payload_copy = &payload_copy,
+        .payload_free = &payload_free
+    };
+
+    return inquery_object_new(payload_new(INQUERY_VALUE_TYPE_INT, 
+            sizeof (uint64_t), NULL), &vt);
+}
+
+
+extern inquery_value *inquery_value_new_real(double val)
+{
+    struct inquery_object_vtable vt = {
+        .payload_copy = &payload_copy,
+        .payload_free = &payload_free
+    };
+
+    return inquery_object_new(payload_new(INQUERY_VALUE_TYPE_REAL, 
+            sizeof (double), &val), &vt);
+}
+
+
+extern inquery_value *inquery_value_new_real_nil(void)
+{
+    struct inquery_object_vtable vt = {
+        .payload_copy = &payload_copy,
+        .payload_free = &payload_free
+    };
+
+    return inquery_object_new(payload_new(INQUERY_VALUE_TYPE_REAL, 
+            sizeof (double), NULL), &vt);
+}
+
+
+extern inquery_value *inquery_value_new_text(const inquery_string *val)
+{
+    inquery_assert (val);
+
+    struct inquery_object_vtable vt = {
+        .payload_copy = &payload_copy,
+        .payload_free = &payload_free
+    };
+
+    return inquery_object_new(payload_new(INQUERY_VALUE_TYPE_TEXT, 
+            inquery_string_sz(val), val), &vt);
+}
+
+
+extern inquery_value *inquery_value_new_text_nil(void)
+{
+    struct inquery_object_vtable vt = {
+        .payload_copy = &payload_copy,
+        .payload_free = &payload_free
+    };
+
+    return inquery_object_new(payload_new(INQUERY_VALUE_TYPE_TEXT, 0, NULL),
+            &vt);
+}
+
+
+extern inline inquery_value *inquery_value_copy(const inquery_value *ctx);
+
+
+extern inline void inquery_value_free(inquery_value **ctx);
+
+
+extern bool inquery_value_nil(const inquery_value *ctx)
+{
+    inquery_assert (ctx);
+
+    const struct payload *payload = inquery_object_payload(ctx);
+    return !payload->value;
+}
+
+
+extern enum inquery_value_type inquery_value_type(const inquery_value *ctx)
+{
+    inquery_assert (ctx);
+
+    const struct payload *payload = inquery_object_payload(ctx);
+    return payload->type;
+}
+
+
+extern uint64_t inquery_value_int(const inquery_value *ctx)
+{
+    inquery_assert (ctx);
+
+    const struct payload *payload = inquery_object_payload(ctx);
+    inquery_assert (payload->type == INQUERY_VALUE_TYPE_INT);
+
+    return *((uint64_t *) payload->value);
+}
+
+
+extern double inquery_value_real(const inquery_value *ctx)
+{
+    inquery_assert (ctx);
+
+    const struct payload *payload = inquery_object_payload(ctx);
+    inquery_assert (payload->type == INQUERY_VALUE_TYPE_REAL);
+
+    return *((double *) payload->value);
+}
+
+
+extern inquery_string *inquery_value_text(const inquery_value *ctx)
+{
+    inquery_assert (ctx);
+
+    const struct payload *payload = inquery_object_payload(ctx);
+    inquery_assert (payload->type == INQUERY_VALUE_TYPE_TEXT);
+
+    return inquery_string_copy((inquery_string *) payload->value);
+}
+

--- a/lib/core/value.c
+++ b/lib/core/value.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <float.h>
 #include <math.h>
 #include <string.h>
@@ -289,4 +290,44 @@ extern inquery_string *inquery_value_text(const inquery_value *ctx)
 
     return inquery_string_copy((inquery_string *) payload->value);
 }
+
+
+/*
+ * inquery_value_string() - get string representation of value
+ */
+extern inquery_string *inquery_value_string(const inquery_value *ctx)
+{
+    inquery_assert (ctx);
+
+    const struct payload *payload = inquery_object_payload(ctx);
+
+    switch (payload->type) {
+        case INQUERY_VALUE_TYPE_NIL:
+            return inquery_string_new("(nil)");
+
+        case INQUERY_VALUE_TYPE_INT: {
+            int64_t val = *((int64_t *) payload->value);
+            size_t len = snprintf(NULL, 0, "%"PRId64, val) + 1;
+
+            inquery_string *str = inquery_heap_new(sizeof *str * len);
+            (void) snprintf(str, len, "%"PRId64, val);
+    
+            return str;
+        }
+
+        case INQUERY_VALUE_TYPE_REAL: {
+            double val = *((double *) payload->value);
+            size_t len = snprintf(NULL, 0, "%lf", val) + 1;
+
+            inquery_string *str = inquery_heap_new(sizeof *str * len);
+            snprintf(str, len, "%lf", val);
+
+            return str;
+        }
+
+        default:
+            return inquery_value_text(ctx);
+    }
+}
+
 

--- a/lib/core/value.c
+++ b/lib/core/value.c
@@ -57,7 +57,7 @@ static void payload_free(void *ctx)
 /*
  * inquery_value_new_int() - create new integer value
  */
-extern inquery_value *inquery_value_new_int(uint64_t val)
+extern inquery_value *inquery_value_new_int(int64_t val)
 {
     struct inquery_object_vtable vt = {
         .payload_copy = &payload_copy,
@@ -65,7 +65,7 @@ extern inquery_value *inquery_value_new_int(uint64_t val)
     };
 
     return inquery_object_new(payload_new(INQUERY_VALUE_TYPE_INT, 
-            sizeof (uint64_t), &val), &vt);
+            sizeof (int64_t), &val), &vt);
 }
 
 
@@ -80,7 +80,7 @@ extern inquery_value *inquery_value_new_int_nil(void)
     };
 
     return inquery_object_new(payload_new(INQUERY_VALUE_TYPE_INT, 
-            sizeof (uint64_t), NULL), &vt);
+            sizeof (int64_t), NULL), &vt);
 }
 
 
@@ -185,14 +185,14 @@ extern enum inquery_value_type inquery_value_type(const inquery_value *ctx)
 /*
  * inquery_value_int() - unbox integer value
  */
-extern uint64_t inquery_value_int(const inquery_value *ctx)
+extern int64_t inquery_value_int(const inquery_value *ctx)
 {
     inquery_assert (ctx);
 
     const struct payload *payload = inquery_object_payload(ctx);
     inquery_assert (payload->type == INQUERY_VALUE_TYPE_INT);
 
-    return *((uint64_t *) payload->value);
+    return *((int64_t *) payload->value);
 }
 
 

--- a/lib/core/value.c
+++ b/lib/core/value.c
@@ -83,12 +83,14 @@ static inline int cmp_int(int64_t lhs, int64_t rhs)
 /*
  * cmp_real() - compare two real values
  */
-static inline int cmp_real(double lhs, double rhs)
+static inline int cmp_real(double a, double b)
 {
-    if (fabs(lhs - rhs) < DBL_EPSILON)
+    /* https://stackoverflow.com/questions/17333 */
+
+    if (fabs(a - b) <= ( (fabs(a) > fabs(b) ? fabs(b) : fabs(a)) * DBL_EPSILON))
         return 0;
 
-    if (fabs(rhs - lhs) > DBL_EPSILON)
+    if ((b - a) > ( (fabs(a) < fabs(b) ? fabs(b) : fabs(a)) * DBL_EPSILON))
         return -1;
 
     return 1;

--- a/lib/core/value.c
+++ b/lib/core/value.c
@@ -98,7 +98,7 @@ static inline int cmp_real(double a, double b)
 
 
 /*
- * inquery_value_nil() - check if value is nil
+ * inquery_value_new() - create new nil value
  */
 extern inquery_value *inquery_value_new(void)
 {

--- a/test/attribute.c
+++ b/test/attribute.c
@@ -1,0 +1,237 @@
+#include "../lib/core/core.h"
+#include "suite.h"
+
+
+/*
+ * new_l() - test case for inquery_attribute_new()
+ */
+static void new_1(void)
+{
+    printf("inquery_attribute_new() creates a new nil attribute...");
+
+    inquery_attribute_smart *test = inquery_attribute_new_nil("test");
+    inquery_require (inquery_attribute_nil(test));
+
+    printf("OK\n");
+}
+
+
+/*
+ * new_int_1() - test case for inquery_attribute_new_int()
+ */
+static void new_int_1(void)
+{
+    printf("inquery_attribute_new_int() creates a new integer attribute...");
+
+    inquery_attribute_smart *test = inquery_attribute_new_int("test", -555);
+    inquery_require (inquery_attribute_int(test) == -555);
+
+    printf("OK\n");
+}
+
+
+/*
+ * new_real_1() - test case for inquery_attribute_new_real()
+ */
+static void new_real_1(void)
+{
+    printf("inquery_attribute_new_int() creates a new real attribute...");
+
+    inquery_attribute_smart *test = inquery_attribute_new_real("test", 
+            -555.555);
+    inquery_require (inquery_attribute_real(test) == -555.555);
+
+    printf("OK\n");
+}
+
+
+/*
+ * new_text_1() - test case for inquery_attribute_new_text()
+ */
+static void new_text_1(void)
+{
+    printf("inquery_attribute_new_text() creates a new text attribute...");
+
+    inquery_attribute_smart *test = inquery_attribute_new_text("test",
+            "Hello, world!");
+    inquery_string_smart *check = inquery_attribute_text(test);
+    inquery_require (inquery_string_eq(check, "Hello, world!"));
+
+    printf("OK\n");
+}
+
+
+/*
+ * lt_1() - test case #1 for inquery_attribute_lt()
+ */
+static void lt_1(void)
+{
+    printf("inquery_attribute_lt() determines if an integer attribute is less"
+           " than another");
+
+    inquery_attribute_smart *lhs = inquery_attribute_new_int("test", -555);
+    inquery_attribute_smart *rhs = inquery_attribute_new_int("test", 666);
+    inquery_require (inquery_attribute_lt(lhs, rhs));
+
+    printf("...OK\n");
+}
+
+
+/*
+ * lt_2() - test case #2 for inquery_attribute_lt()
+ */
+static void lt_2(void)
+{
+    printf("inquery_attribute_lt() determines if a real attribute is less than"
+            " another");
+
+    inquery_attribute_smart *lhs = inquery_attribute_new_real("test", -555.56);
+    inquery_attribute_smart *rhs = inquery_attribute_new_real("test", -555.55);
+    inquery_require (inquery_attribute_lt(lhs, rhs));
+
+    printf("...OK\n");
+}
+
+
+/*
+ * lt_3() - test case #3 for inquery_attribute_lt()
+ */
+static void lt_3(void)
+{
+    printf("inquery_attribute_lt() determines if a text attribute is less than"
+            " another");
+
+    inquery_attribute_smart *lhs = inquery_attribute_new_text("test", "A man");
+    inquery_attribute_smart *rhs = inquery_attribute_new_text("test", 
+            "A woman");
+    inquery_require (inquery_attribute_lt(lhs, rhs));
+
+    printf("...OK\n");
+}
+
+
+/*
+ * eq_1() - test case #1 for inquery_attribute_eq()
+ */
+static void eq_1(void)
+{
+    printf("inquery_attribute_eq() determines if an integer attribute is equal"
+            " to another");
+
+    inquery_attribute_smart *lhs = inquery_attribute_new_int("test", -555);
+    inquery_attribute_smart *rhs = inquery_attribute_new_int("test", -555);
+    inquery_require (inquery_attribute_eq(lhs, rhs));
+
+    printf("...OK\n");
+}
+
+
+/*
+ * eq_2() - test case #2 for inquery_attribute_eq()
+ */
+static void eq_2(void)
+{
+    printf("inquery_attribute_eq() determines if a real attribute is equal to"
+            " another");
+    
+    inquery_attribute_smart *lhs = inquery_attribute_new_real("test", -555.55);
+    inquery_attribute_smart *rhs = inquery_attribute_new_real("test", -555.55);
+    inquery_require (inquery_attribute_eq(lhs, rhs));
+
+    printf("...OK\n");
+}
+
+
+/*
+ * eq_3() - test case #3 for inquery_attribute_eq()
+ */
+static void eq_3(void)
+{
+    printf("inquery_attribute_eq() determines if a text attribute is equal to"
+            " another");
+    
+    inquery_attribute_smart *lhs = inquery_attribute_new_text("test", "A man");
+    inquery_attribute_smart *rhs = inquery_attribute_new_text("test", "A man");
+    inquery_require (inquery_attribute_eq(lhs, rhs));
+
+    printf("...OK\n");
+}
+
+
+/*
+ * gt_1() - test case #1 for inquery_attribute_gt()
+ */
+static void gt_1(void)
+{
+    printf("inquery_attribute_gt() determines if an integer attribute is"
+            " greater than another");
+
+    inquery_attribute_smart *lhs = inquery_attribute_new_int("test", 555);
+    inquery_attribute_smart *rhs = inquery_attribute_new_int("test", -666);
+    inquery_require (inquery_attribute_gt(lhs, rhs));
+
+    printf("...OK\n");
+}
+
+
+/*
+ * gt_2() - test case #2 for inquery_attribute_gt()
+ */
+static void gt_2(void)
+{
+    printf("inquery_attribute_gt() determines if a real attribute is greater"
+            " than another");
+
+    inquery_attribute_smart *lhs = inquery_attribute_new_real("test", 666.66);
+    inquery_attribute_smart *rhs = inquery_attribute_new_real("test", 555.65);
+    inquery_require (inquery_attribute_gt(lhs, rhs));
+
+    printf("...OK\n");
+}
+
+
+/*
+ * gt_3() - test case #3 for inquery_attribute_gt()
+ */
+static void gt_3(void)
+{
+    printf("inquery_attribute_gt() determines if a text attribute is greater"
+            " than another");
+
+    inquery_attribute_smart *lhs = inquery_attribute_new_text("test", 
+            "A woman");
+    inquery_attribute_smart *rhs = inquery_attribute_new_text("test", "A man");
+    inquery_require (inquery_attribute_gt(lhs, rhs));
+
+    printf("...OK\n");
+}
+
+
+/*
+ * inquery_test_suite_attribute() - attribute interface test suite
+ */
+extern void inquery_test_suite_attribute(void)
+{
+    printf("===============================================================\n");
+    printf("Starting attribute interface test suite...\n\n");
+
+    new_1();
+    new_int_1();
+    new_real_1();
+    new_text_1();
+
+    lt_1();
+    lt_2();
+    lt_3();
+
+    eq_1();
+    eq_2();
+    eq_3();
+
+    gt_1();
+    gt_2();
+    gt_3();
+
+    printf("\n");
+}
+

--- a/test/runner.c
+++ b/test/runner.c
@@ -10,6 +10,7 @@ int main(int argc, char **argv)
     inquery_test_suite_string();
     inquery_test_suite_object();
     inquery_test_suite_value();
+    inquery_test_suite_attribute();
 
     return 0;
 }

--- a/test/runner.c
+++ b/test/runner.c
@@ -9,6 +9,7 @@ int main(int argc, char **argv)
     inquery_test_suite_heap();
     inquery_test_suite_string();
     inquery_test_suite_object();
+    inquery_test_suite_value();
 
     return 0;
 }

--- a/test/suite.h
+++ b/test/suite.h
@@ -19,5 +19,11 @@ extern void inquery_test_suite_string(void);
 extern void inquery_test_suite_object(void);
 
 
+/*
+ * inquery_test_suite_value() - value interface test suite
+ */
+extern void inquery_test_suite_value(void);
+
+
 #endif /* INQUERY_TEST_SUITE_HEADER */
 

--- a/test/suite.h
+++ b/test/suite.h
@@ -25,5 +25,11 @@ extern void inquery_test_suite_object(void);
 extern void inquery_test_suite_value(void);
 
 
+/*
+ * inquery_test_suite_attribute() - attribute interface test suite
+ */
+extern void inquery_test_suite_attribute(void);
+
+
 #endif /* INQUERY_TEST_SUITE_HEADER */
 

--- a/test/value.c
+++ b/test/value.c
@@ -3,9 +3,23 @@
 
 
 /*
- * new_int() - test case for inquery_value_new_int()
+ * new_l() - test case for inquery_value_new()
  */
-static void new_int(void)
+static void new_1(void)
+{
+    printf("inquery_value_new() creates a new nil value...");
+
+    inquery_value_smart *test = inquery_value_new();
+    inquery_require (inquery_value_nil(test));
+
+    printf("OK\n");
+}
+
+
+/*
+ * new_int_1() - test case for inquery_value_new_int()
+ */
+static void new_int_1(void)
 {
     printf("inquery_value_new_int() creates a new boxed integer value...");
 
@@ -17,23 +31,9 @@ static void new_int(void)
 
 
 /*
- * new_int_nil() - test case for inquery_value_new_int_nil()
+ * new_real_1() - test case for inquery_value_new_real()
  */
-static void new_int_nil(void)
-{
-    printf("inquery_value_new_int_nil() creates a new nil integer value...");
-
-    inquery_value_smart *test = inquery_value_new_int_nil();
-    inquery_require (inquery_value_nil(test));
-
-    printf("OK\n");
-}
-
-
-/*
- * new_real() - test case for inquery_value_new_real()
- */
-static void new_real(void)
+static void new_real_1(void)
 {
     printf("inquery_value_new_int() creates a new boxed real value...");
 
@@ -45,23 +45,9 @@ static void new_real(void)
 
 
 /*
- * new_real_nil() - test case for inquery_value_new_real_nil()
+ * new_text_1() - test case for inquery_value_new_text()
  */
-static void new_real_nil(void)
-{
-    printf("inquery_value_new_int() creates a new nil real value...");
-
-    inquery_value_smart *test = inquery_value_new_real_nil();
-    inquery_require (inquery_value_nil(test));
-
-    printf("OK\n");
-}
-
-
-/*
- * new_text() - test case for inquery_value_new_text()
- */
-static void new_text(void)
+static void new_text_1(void)
 {
     printf("inquery_value_new_text() creates a new boxed text value...");
 
@@ -73,33 +59,15 @@ static void new_text(void)
 }
 
 
-/*
- * new_text_nil() - test case for inquery_value_new_text_nil()
- */
-static void new_text_nil(void)
-{
-    printf("inquery_value_new_text_nil() creates a new nil text value...");
-
-    inquery_value_smart *test = inquery_value_new_text_nil();
-    inquery_require (inquery_value_nil(test));
-
-    printf("OK\n");
-}
-
-
 extern void inquery_test_suite_value(void)
 {
     printf("===============================================================\n");
     printf("Starting value interface test suite...\n\n");
 
-    new_int();
-    new_int_nil();
-
-    new_real();
-    new_real_nil();
-
-    new_text();
-    new_text_nil();
+    new_1();
+    new_int_1();
+    new_real_1();
+    new_text_1();
 
     printf("\n");
 }

--- a/test/value.c
+++ b/test/value.c
@@ -1,0 +1,107 @@
+#include "../lib/core/core.h"
+#include "suite.h"
+
+
+/*
+ * new_int() - test case for inquery_value_new_int()
+ */
+static void new_int(void)
+{
+    printf("inquery_value_new_int() creates a new boxed integer value...");
+
+    inquery_value_smart *test = inquery_value_new_int(-555);
+    inquery_require (inquery_value_int(test) == -555);
+
+    printf("OK\n");
+}
+
+
+/*
+ * new_int_nil() - test case for inquery_value_new_int_nil()
+ */
+static void new_int_nil(void)
+{
+    printf("inquery_value_new_int_nil() creates a new nil integer value...");
+
+    inquery_value_smart *test = inquery_value_new_int_nil();
+    inquery_require (inquery_value_nil(test));
+
+    printf("OK\n");
+}
+
+
+/*
+ * new_real() - test case for inquery_value_new_real()
+ */
+static void new_real(void)
+{
+    printf("inquery_value_new_int() creates a new boxed real value...");
+
+    inquery_value_smart *test = inquery_value_new_real(-555.555);
+    inquery_require (inquery_value_real(test) == -555.555);
+
+    printf("OK\n");
+}
+
+
+/*
+ * new_real_nil() - test case for inquery_value_new_real_nil()
+ */
+static void new_real_nil(void)
+{
+    printf("inquery_value_new_int() creates a new nil real value...");
+
+    inquery_value_smart *test = inquery_value_new_real_nil();
+    inquery_require (inquery_value_nil(test));
+
+    printf("OK\n");
+}
+
+
+/*
+ * new_text() - test case for inquery_value_new_text()
+ */
+static void new_text(void)
+{
+    printf("inquery_value_new_text() creates a new boxed text value...");
+
+    inquery_value_smart *test = inquery_value_new_text("Hello, world!");
+    inquery_string_smart *check = inquery_value_text(test);
+    inquery_require (inquery_string_eq(check, "Hello, world!"));
+
+    printf("OK\n");
+}
+
+
+/*
+ * new_text_nil() - test case for inquery_value_new_text_nil()
+ */
+static void new_text_nil(void)
+{
+    printf("inquery_value_new_text_nil() creates a new nil text value...");
+
+    inquery_value_smart *test = inquery_value_new_text_nil();
+    inquery_require (inquery_value_nil(test));
+
+    printf("OK\n");
+}
+
+
+extern void inquery_test_suite_value(void)
+{
+    printf("===============================================================\n");
+    printf("Starting value interface test suite...\n\n");
+
+    new_int();
+    new_int_nil();
+
+    new_real();
+    new_real_nil();
+
+    new_text();
+    new_text_nil();
+
+    printf("\n");
+}
+
+

--- a/test/value.c
+++ b/test/value.c
@@ -59,6 +59,148 @@ static void new_text_1(void)
 }
 
 
+/*
+ * lt_1() - test case #1 for inquery_value_lt()
+ */
+static void lt_1(void)
+{
+    printf("inquery_value_lt() determines if an integer value is less than"
+            " another");
+
+    inquery_value_smart *lhs = inquery_value_new_int(-555);
+    inquery_value_smart *rhs = inquery_value_new_int(666);
+    inquery_require (inquery_value_lt(lhs, rhs));
+
+    printf("...OK\n");
+}
+
+
+/*
+ * lt_2() - test case #2 for inquery_value_lt()
+ */
+static void lt_2(void)
+{
+    printf("inquery_value_lt() determines if a real value is less than"
+            " another");
+
+    inquery_value_smart *lhs = inquery_value_new_real(-555.56);
+    inquery_value_smart *rhs = inquery_value_new_real(-555.55);
+    inquery_require (inquery_value_lt(lhs, rhs));
+
+    printf("...OK\n");
+}
+
+
+/*
+ * lt_3() - test case #3 for inquery_value_lt()
+ */
+static void lt_3(void)
+{
+    printf("inquery_value_lt() determines if a text value is less than"
+            " another");
+
+    inquery_value_smart *lhs = inquery_value_new_text("A man");
+    inquery_value_smart *rhs = inquery_value_new_text("A woman");
+    inquery_require (inquery_value_lt(lhs, rhs));
+
+    printf("...OK\n");
+}
+
+
+/*
+ * eq_1() - test case #1 for inquery_value_eq()
+ */
+static void eq_1(void)
+{
+    printf("inquery_value_eq() determines if an integer value is equal to"
+            " another");
+
+    inquery_value_smart *lhs = inquery_value_new_int(-555);
+    inquery_value_smart *rhs = inquery_value_new_int(-555);
+    inquery_require (inquery_value_eq(lhs, rhs));
+
+    printf("...OK\n");
+}
+
+
+/*
+ * eq_2() - test case #2 for inquery_value_eq()
+ */
+static void eq_2(void)
+{
+    printf("inquery_value_eq() determines if a real value is equal to another");
+    
+    inquery_value_smart *lhs = inquery_value_new_real(-555.55);
+    inquery_value_smart *rhs = inquery_value_new_real(-555.55);
+    inquery_require (inquery_value_eq(lhs, rhs));
+
+    printf("...OK\n");
+}
+
+
+/*
+ * eq_3() - test case #3 for inquery_value_eq()
+ */
+static void eq_3(void)
+{
+    printf("inquery_value_eq() determines if a text value is equal to another");
+    
+    inquery_value_smart *lhs = inquery_value_new_text("A man");
+    inquery_value_smart *rhs = inquery_value_new_text("A man");
+    inquery_require (inquery_value_eq(lhs, rhs));
+
+    printf("...OK\n");
+}
+
+
+/*
+ * gt_1() - test case #1 for inquery_value_gt()
+ */
+static void gt_1(void)
+{
+    printf("inquery_value_gt() determines if an integer value is greater than"
+            " another");
+
+    inquery_value_smart *lhs = inquery_value_new_int(555);
+    inquery_value_smart *rhs = inquery_value_new_int(-666);
+    inquery_require (inquery_value_gt(lhs, rhs));
+
+    printf("...OK\n");
+}
+
+
+/*
+ * gt_2() - test case #2 for inquery_value_gt()
+ */
+static void gt_2(void)
+{
+    printf("inquery_value_gt() determines if a real value is greater than"
+            " another");
+
+    inquery_value_smart *lhs = inquery_value_new_real(666.66);
+    inquery_value_smart *rhs = inquery_value_new_real(555.65);
+    inquery_require (inquery_value_gt(lhs, rhs));
+
+    printf("...OK\n");
+}
+
+
+/*
+ * gt_3() - test case #3 for inquery_value_gt()
+ */
+static void gt_3(void)
+{
+    printf("inquery_value_gt() determines if a text value is greater than"
+            " another");
+
+    inquery_value_smart *lhs = inquery_value_new_text("A woman");
+    inquery_value_smart *rhs = inquery_value_new_text("A man");
+    inquery_require (inquery_value_gt(lhs, rhs));
+
+    printf("...OK\n");
+}
+
+
 extern void inquery_test_suite_value(void)
 {
     printf("===============================================================\n");
@@ -68,6 +210,18 @@ extern void inquery_test_suite_value(void)
     new_int_1();
     new_real_1();
     new_text_1();
+
+    lt_1();
+    lt_2();
+    lt_3();
+
+    eq_1();
+    eq_2();
+    eq_3();
+
+    gt_1();
+    gt_2();
+    gt_3();
 
     printf("\n");
 }


### PR DESCRIPTION
The attribute interface has been created with the following functions:
  * `inquery_attribute_new()`
  * `inquery_attribute_new_nil()`
  * `inquery_attribute_new_int()`
  * `inquery_attribute_new_real()`
  * `inquery_attribute_new_text()`
  * `inquery_attribute_copy()`
  * `inquery_attribute_free()`
  * `inquery_attribute_key()`
  * `inquery_attribute_value()`
  * `inquery_attribute_type()`
  * `inquery_attribute_cmp()`
  * `inquery_attribute_lt()`
  * `inquery_attribute_lteq()`
  * `inquery_attribute_eq()`
  * `inquery_attribute_gteq()`
  * `inquery_attribute_gt()`
  * `inquery_attribute_nil()`
  * `inquery_attribute_int()`
  * `inquery_attribute_real()`
  * `inquery_attribute_text()`
  * `inquery_attribute_string()`
  * `inquery_attribute_json()`

Supporting this interface is the `inquery_attribute` type, which is a specialisation of the `inquery_object` type. The `inquery_attribute_smart` type has also been defined as a specialised form of `inquery_attribute` that supports automatic release when it is out of scope.

Parallel to the `inquery_attribute` interface, the `inquery_value` interface has also been created to handle the functionality related to boxed values which are contained within attributes. Although the interface for `inquery_value` is currently public, I plan to merge it soon into the attribute interface.

This pull request closes issue #14.